### PR TITLE
🔧 Add interpolate option to spectral grid classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.1.0-beta.3] - 2025-05-28
+
+### Added
+- Option to disable interpolation in `SpectralGrid`, `BinnedSpectralGrid`, and `SEDGrid` via `interpolate=False`.
+- Tests for nearest-neighbor retrieval.
+- Test to ensure `speclib.__version__` matches the version in `pyproject.toml`.
+
+### Changed
+- `__version__` is now read from `pyproject.toml` using `importlib.metadata`.
+
+---
 
 ## [0.1.0-beta.2] – 2025-05-23
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "speclib"
-version = "0.1.0-beta.2"
+version = "0.1.0-beta.3"
 description = "Tools for working with stellar spectral libraries."
 authors = [
   { name = "Benjamin V. Rackham" }

--- a/src/speclib/__init__.py
+++ b/src/speclib/__init__.py
@@ -2,7 +2,12 @@
 speclib: Tools for working with stellar spectral libraries.
 """
 
-__version__ = "0.1.0"
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("speclib")
+except PackageNotFoundError:
+    __version__ = "unknown"
 
 from .core import Spectrum, BinnedSpectrum, SpectralGrid, BinnedSpectralGrid
 from .photometry import Filter, SED, SEDGrid, apply_filter, mag_to_flux

--- a/tests/test_interpolation_toggle.py
+++ b/tests/test_interpolation_toggle.py
@@ -1,0 +1,75 @@
+import pytest
+import astropy.units as u
+import numpy as np
+
+from speclib import SpectralGrid, BinnedSpectralGrid
+from speclib.utils import nearest
+
+
+@pytest.fixture
+def spectral_grid():
+    teff_bds = np.array([3000, 4000])
+    logg_bds = np.array([4.5, 5.0])
+    feh_bds = np.array([0.0, 0.5])
+    fluxes = {
+        3000: {4.5: {0.0: np.ones(10) * 1.0}},
+        4000: {4.5: {0.0: np.ones(10) * 2.0}},
+    }
+    wavelengths = np.linspace(1.0, 2.0, 10) * u.um
+    return SpectralGrid(
+        teff_bds=teff_bds,
+        logg_bds=logg_bds,
+        feh_bds=feh_bds,
+        fluxes=fluxes,
+        wavelengths=wavelengths,
+    )
+
+
+@pytest.fixture
+def binned_grid(spectral_grid):
+    return BinnedSpectralGrid.from_spectral_grid(
+        spectral_grid, bin_edges=np.linspace(1.0, 2.0, 6) * u.um
+    )
+
+
+def test_spectral_grid_get_spectrum_nearest_exact_match(spectral_grid):
+    teff, logg, feh = (
+        spectral_grid.teffs[0],
+        spectral_grid.loggs[0],
+        spectral_grid.fehs[0],
+    )
+    spec_interp = spectral_grid.get_spectrum(teff, logg, feh, interpolate=True)
+    spec_nearest = spectral_grid.get_spectrum(teff, logg, feh, interpolate=False)
+    assert u.allclose(spec_interp, spec_nearest)
+
+
+def test_spectral_grid_get_spectrum_nearest_off_grid(spectral_grid):
+    teff = spectral_grid.teffs[0] + 10
+    logg = spectral_grid.loggs[0]
+    feh = spectral_grid.fehs[0]
+    spec = spectral_grid.get_spectrum(teff, logg, feh, interpolate=False)
+
+    teff_nearest = nearest(spectral_grid.teffs, teff)
+    expected = spectral_grid.get_spectrum(teff_nearest, logg, feh, interpolate=False)
+    assert u.allclose(spec, expected)
+
+
+def test_interpolated_vs_nearest_spectrum_differ(spectral_grid):
+    teff = (spectral_grid.teffs[0] + spectral_grid.teffs[1]) / 2
+    logg = spectral_grid.loggs[0]
+    feh = spectral_grid.fehs[0]
+
+    interp_spec = spectral_grid.get_spectrum(teff, logg, feh, interpolate=True)
+    nearest_spec = spectral_grid.get_spectrum(teff, logg, feh, interpolate=False)
+    assert not u.allclose(interp_spec, nearest_spec)
+
+
+def test_binned_grid_get_spectrum_nearest_off_grid(binned_grid):
+    teff = binned_grid.teffs[0] + 10
+    logg = binned_grid.loggs[0]
+    feh = binned_grid.fehs[0]
+    spec = binned_grid.get_spectrum(teff, logg, feh, interpolate=False)
+
+    teff_nearest = nearest(binned_grid.teffs, teff)
+    expected = binned_grid.get_spectrum(teff_nearest, logg, feh, interpolate=False)
+    assert u.allclose(spec, expected)

--- a/tests/test_interpolation_toggle.py
+++ b/tests/test_interpolation_toggle.py
@@ -1,75 +1,54 @@
 import pytest
-import astropy.units as u
 import numpy as np
+import astropy.units as u
 
-from speclib import SpectralGrid, BinnedSpectralGrid
-from speclib.utils import nearest
+from speclib.core import SpectralGrid, BinnedSpectralGrid
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def spectral_grid():
-    teff_bds = np.array([3000, 4000])
-    logg_bds = np.array([4.5, 5.0])
-    feh_bds = np.array([0.0, 0.5])
-    fluxes = {
-        3000: {4.5: {0.0: np.ones(10) * 1.0}},
-        4000: {4.5: {0.0: np.ones(10) * 2.0}},
-    }
-    wavelengths = np.linspace(1.0, 2.0, 10) * u.um
     return SpectralGrid(
-        teff_bds=teff_bds,
-        logg_bds=logg_bds,
-        feh_bds=feh_bds,
-        fluxes=fluxes,
-        wavelengths=wavelengths,
-    )
-
-
-@pytest.fixture
-def binned_grid(spectral_grid):
-    return BinnedSpectralGrid.from_spectral_grid(
-        spectral_grid, bin_edges=np.linspace(1.0, 2.0, 6) * u.um
+        teff_bds=(3700, 3900),
+        logg_bds=(4.5, 5.0),
+        feh_bds=(0.0, 0.0),
+        model_grid="phoenix",
+        wavelength=np.linspace(1.0, 2.0, 100) * u.micron,
     )
 
 
 def test_spectral_grid_get_spectrum_nearest_exact_match(spectral_grid):
-    teff, logg, feh = (
-        spectral_grid.teffs[0],
-        spectral_grid.loggs[0],
-        spectral_grid.fehs[0],
-    )
-    spec_interp = spectral_grid.get_spectrum(teff, logg, feh, interpolate=True)
-    spec_nearest = spectral_grid.get_spectrum(teff, logg, feh, interpolate=False)
-    assert u.allclose(spec_interp, spec_nearest)
+    spec_interp = spectral_grid.get_spectrum(3800, 4.5, 0.0, interpolate=True)
+    spec_nearest = spectral_grid.get_spectrum(3800, 4.5, 0.0, interpolate=False)
+    np.testing.assert_allclose(spec_interp.value, spec_nearest.value, rtol=1e-5)
 
 
 def test_spectral_grid_get_spectrum_nearest_off_grid(spectral_grid):
-    teff = spectral_grid.teffs[0] + 10
-    logg = spectral_grid.loggs[0]
-    feh = spectral_grid.fehs[0]
-    spec = spectral_grid.get_spectrum(teff, logg, feh, interpolate=False)
-
-    teff_nearest = nearest(spectral_grid.teffs, teff)
-    expected = spectral_grid.get_spectrum(teff_nearest, logg, feh, interpolate=False)
-    assert u.allclose(spec, expected)
+    spec_nearest = spectral_grid.get_spectrum(3820, 4.5, 0.0, interpolate=False)
+    spec_base = spectral_grid.get_spectrum(3800, 4.5, 0.0, interpolate=False)
+    assert np.allclose(spec_nearest.value, spec_base.value)
 
 
 def test_interpolated_vs_nearest_spectrum_differ(spectral_grid):
-    teff = (spectral_grid.teffs[0] + spectral_grid.teffs[1]) / 2
-    logg = spectral_grid.loggs[0]
-    feh = spectral_grid.fehs[0]
-
-    interp_spec = spectral_grid.get_spectrum(teff, logg, feh, interpolate=True)
-    nearest_spec = spectral_grid.get_spectrum(teff, logg, feh, interpolate=False)
-    assert not u.allclose(interp_spec, nearest_spec)
+    spec_interp = spectral_grid.get_spectrum(3820, 4.5, 0.0, interpolate=True)
+    spec_nearest = spectral_grid.get_spectrum(3820, 4.5, 0.0, interpolate=False)
+    assert not np.allclose(spec_interp.value, spec_nearest.value)
 
 
-def test_binned_grid_get_spectrum_nearest_off_grid(binned_grid):
-    teff = binned_grid.teffs[0] + 10
-    logg = binned_grid.loggs[0]
-    feh = binned_grid.fehs[0]
-    spec = binned_grid.get_spectrum(teff, logg, feh, interpolate=False)
+def test_binned_grid_get_spectrum_nearest_off_grid(spectral_grid):
+    center = np.linspace(1.0, 2.0, 6) * u.micron
+    width = np.full_like(center, fill_value=(center[1] - center[0]))
 
-    teff_nearest = nearest(binned_grid.teffs, teff)
-    expected = binned_grid.get_spectrum(teff_nearest, logg, feh, interpolate=False)
-    assert u.allclose(spec, expected)
+    grid = BinnedSpectralGrid(
+        teff_bds=(3700, 3900),
+        logg_bds=(4.5, 5.0),
+        feh_bds=(0.0, 0.0),
+        center=center,
+        width=width,
+        model_grid="phoenix",
+        wavelength=spectral_grid.wavelength,
+    )
+
+    spec_interp = grid.get_spectrum(3820, 4.5, 0.0, interpolate=True)
+    spec_nearest = grid.get_spectrum(3820, 4.5, 0.0, interpolate=False)
+
+    assert not np.allclose(spec_interp.value, spec_nearest.value)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,10 @@
+import importlib.metadata
+import speclib
+
+
+def test_version_matches_pyproject():
+    """
+    Ensure that speclib.__version__ matches the version in pyproject.toml.
+    """
+    expected = importlib.metadata.version("speclib")
+    assert speclib.__version__ == expected


### PR DESCRIPTION
## 🔧 Add `interpolate` option to spectral grid classes

Closes #17

This PR introduces a new `interpolate` keyword argument to the following classes:

- `SpectralGrid.get_spectrum`
- `BinnedSpectralGrid.get_spectrum`
- `SEDGrid.get_spectrum`

When `interpolate=False`, the method returns the nearest grid point instead of using trilinear interpolation. This enables explicit control over interpolation behavior, which can be useful for debugging, validation, and analysis requiring strict grid adherence.

---

### ✨ Features Added
- `interpolate` option added to all `get_spectrum()` methods in grid classes
- When `False`, spectrum is returned from nearest available grid point
- Fully backwards-compatible (defaults to `interpolate=True`)

### 🧪 Tests Added
- `test_get_spectrum_interpolate_false_returns_nearest`  
- `test_get_spectrum_interpolate_true_differs_from_nearest`  
- `test_binned_grid_get_spectrum_nearest_off_grid`  
- `test_version_matches_pyproject` – ensures `speclib.__version__` matches version in `pyproject.toml`

### 🔧 Internal Improvements
- Removed `__version__` from `__init__.py`
- Now retrieves version dynamically via `importlib.metadata`, in line with modern packaging practices

---

### 📝 Changelog

```markdown
## [0.1.0-beta.3] - 2025-05-28

### Added
- Option to disable interpolation in `SpectralGrid`, `BinnedSpectralGrid`, and `SEDGrid` via `interpolate=False`.
- Tests for nearest-neighbor retrieval.
- Test to ensure `speclib.__version__` matches the version in `pyproject.toml`.

### Changed
- `__version__` is now read from `pyproject.toml` using `importlib.metadata`.
