### PR TITLE
Rename get_spectrum to get_flux for clarity

### DIFF
--- a/src/speclib/core.py
+++ b/src/speclib/core.py
@@ -1009,7 +1009,7 @@ class SpectralGrid(object):
         # Save the wavelength array
         self.wavelength = spec.wavelength
 
-    def get_spectrum(self, teff, logg, feh, interpolate=True):
+    def get_flux(self, teff, logg, feh, interpolate=True):
         """
         Parameters
         ----------

--- a/tests/test_interpolation_toggle.py
+++ b/tests/test_interpolation_toggle.py
@@ -17,20 +17,20 @@ def spectral_grid():
 
 
 def test_spectral_grid_get_spectrum_nearest_exact_match(spectral_grid):
-    spec_interp = spectral_grid.get_spectrum(3800, 4.5, 0.0, interpolate=True)
-    spec_nearest = spectral_grid.get_spectrum(3800, 4.5, 0.0, interpolate=False)
+    spec_interp = spectral_grid.get_flux(3800, 4.5, 0.0, interpolate=True)
+    spec_nearest = spectral_grid.get_flux(3800, 4.5, 0.0, interpolate=False)
     np.testing.assert_allclose(spec_interp.value, spec_nearest.value, rtol=1e-5)
 
 
 def test_spectral_grid_get_spectrum_nearest_off_grid(spectral_grid):
-    spec_nearest = spectral_grid.get_spectrum(3820, 4.5, 0.0, interpolate=False)
-    spec_base = spectral_grid.get_spectrum(3800, 4.5, 0.0, interpolate=False)
+    spec_nearest = spectral_grid.get_flux(3820, 4.5, 0.0, interpolate=False)
+    spec_base = spectral_grid.get_flux(3800, 4.5, 0.0, interpolate=False)
     assert np.allclose(spec_nearest.value, spec_base.value)
 
 
 def test_interpolated_vs_nearest_spectrum_differ(spectral_grid):
-    spec_interp = spectral_grid.get_spectrum(3820, 4.5, 0.0, interpolate=True)
-    spec_nearest = spectral_grid.get_spectrum(3820, 4.5, 0.0, interpolate=False)
+    spec_interp = spectral_grid.get_flux(3820, 4.5, 0.0, interpolate=True)
+    spec_nearest = spectral_grid.get_flux(3820, 4.5, 0.0, interpolate=False)
     assert not np.allclose(spec_interp.value, spec_nearest.value)
 
 
@@ -48,7 +48,7 @@ def test_binned_grid_get_spectrum_nearest_off_grid(spectral_grid):
         wavelength=spectral_grid.wavelength,
     )
 
-    spec_interp = grid.get_spectrum(3820, 4.5, 0.0, interpolate=True)
-    spec_nearest = grid.get_spectrum(3820, 4.5, 0.0, interpolate=False)
+    spec_interp = grid.get_flux(3820, 4.5, 0.0, interpolate=True)
+    spec_nearest = grid.get_flux(3820, 4.5, 0.0, interpolate=False)
 
     assert not np.allclose(spec_interp.value, spec_nearest.value)


### PR DESCRIPTION
Renamed the method get_spectrum to get_flux in the class SpectralGrid and updated the test files which called the old method name to the new one. Aiming to fix github issue #18 