### PR TITLE
✨ Add support for low-resolution NewEra model spectra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.1.0-beta.4] - 2025-05-30
+
+### Added
+- Support for PHOENIX NewEra model grids (`newera_gaia`, `newera_jwst`, `newera_lowres`) via `Spectrum.from_grid()`
+- Utility functions `load_newera_wavelength_array()` and `load_newera_flux_array()` in `utils.py` to handle NewEra file structure
+- Automatic detection of wavelength grid parameters from NewEra file headers
+- Warning when `alpha ≠ 0.0` is requested, as non-zero alpha values may not be reliably supported yet
+
+### Changed
+- Improved error messaging for missing NewEra files to aid debugging and model grid validation
+
+---
+
 ## [0.1.0-beta.3] - 2025-05-28
 
 ### Added

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,12 +8,13 @@
 
 import os
 import sys
+
 sys.path.insert(0, os.path.abspath("../src"))
 
-project = 'speclib'
-copyright = '2025, Benjamin V. Rackham'
-author = 'Benjamin V. Rackham'
-release = '0.1.0'
+project = "speclib"
+copyright = "2025, Benjamin V. Rackham"
+author = "Benjamin V. Rackham"
+release = "0.1.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
@@ -24,13 +25,12 @@ extensions = [
     "sphinx.ext.napoleon",  # if using NumPy or Google-style docstrings
 ]
 
-templates_path = ['_templates']
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
-
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'furo'
-html_static_path = ['_static']
+html_theme = "furo"
+html_static_path = ["_static"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -434,7 +434,7 @@ version = "2025.4.26"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "certifi-2025.4.26-py3-none-any.whl", hash = "sha256:30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3"},
     {file = "certifi-2025.4.26.tar.gz", hash = "sha256:0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6"},
@@ -538,7 +538,7 @@ version = "3.4.2"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 optional = false
 python-versions = ">=3.7"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "charset_normalizer-3.4.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7c48ed483eb946e6c04ccbe02c6b4d1d48e51944b6db70f697e089c193404941"},
     {file = "charset_normalizer-3.4.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b2d318c11350e10662026ad0eb71bb51c7812fc8590825304ae0bdd4ac283acd"},
@@ -640,11 +640,12 @@ version = "0.4.6"
 description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
+markers = {main = "platform_system == \"Windows\""}
 
 [[package]]
 name = "comm"
@@ -1139,7 +1140,7 @@ version = "3.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.6"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
     {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
@@ -2467,7 +2468,7 @@ version = "4.3.8"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "platformdirs-4.3.8-py3-none-any.whl", hash = "sha256:ff7059bb7eb1179e2685604f4aaf157cfd9535242bd23742eadc3c13542139b4"},
     {file = "platformdirs-4.3.8.tar.gz", hash = "sha256:3d512d96e16bcb959a814c9f348431070822a6496326a4be0911c40b5a74c2bc"},
@@ -2493,6 +2494,28 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["coverage", "pytest", "pytest-benchmark"]
+
+[[package]]
+name = "pooch"
+version = "1.8.2"
+description = "A friend to fetch your data files"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "pooch-1.8.2-py3-none-any.whl", hash = "sha256:3529a57096f7198778a5ceefd5ac3ef0e4d06a6ddaf9fc2d609b806f25302c47"},
+    {file = "pooch-1.8.2.tar.gz", hash = "sha256:76561f0de68a01da4df6af38e9955c4c9d1a5c90da73f7e40276a5728ec83d10"},
+]
+
+[package.dependencies]
+packaging = ">=20.0"
+platformdirs = ">=2.5.0"
+requests = ">=2.19.0"
+
+[package.extras]
+progress = ["tqdm (>=4.41.0,<5.0.0)"]
+sftp = ["paramiko (>=2.7.0)"]
+xxhash = ["xxhash (>=1.4.3)"]
 
 [[package]]
 name = "prometheus-client"
@@ -2976,7 +2999,7 @@ version = "2.32.3"
 description = "Python HTTP for Humans."
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"},
     {file = "requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760"},
@@ -3627,6 +3650,28 @@ virtualenv = ">=20.31"
 test = ["devpi-process (>=1.0.2)", "pytest (>=8.3.4)", "pytest-mock (>=3.14)"]
 
 [[package]]
+name = "tqdm"
+version = "4.67.1"
+description = "Fast, Extensible Progress Meter"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2"},
+    {file = "tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+dev = ["nbval", "pytest (>=6)", "pytest-asyncio (>=0.24)", "pytest-cov", "pytest-timeout"]
+discord = ["requests"]
+notebook = ["ipywidgets (>=6)"]
+slack = ["slack-sdk"]
+telegram = ["requests"]
+
+[[package]]
 name = "traitlets"
 version = "5.14.3"
 description = "Traitlets Python configuration system"
@@ -3687,7 +3732,7 @@ version = "2.4.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813"},
     {file = "urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466"},
@@ -3809,4 +3854,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<3.12"
-content-hash = "9e53f719363f6bbd66d21a71c5e2dd740eb8fda68eb42faab3d7c9048dbcf0e9"
+content-hash = "ea20f1fbefe5b3eafcf7d3036c0beb82b9fae24a1a63fdb6fc41ddc9d7eeca4c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "speclib"
-version = "0.1.0-beta.3"
+version = "0.1.0-beta.4"
 description = "Tools for working with stellar spectral libraries."
 authors = [
   { name = "Benjamin V. Rackham" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ dependencies = [
   "pysynphot>=2.0.0,<3.0.0",
   "numpy<2.0",
   "h5py (>=3.13.0,<4.0.0)",
+  "pooch (>=1.8.2,<2.0.0)",
+  "tqdm (>=4.67.1,<5.0.0)",
 ]
 keywords = ["astronomy", "spectra", "stellar libraries"]
 classifiers = [

--- a/src/speclib/core.py
+++ b/src/speclib/core.py
@@ -83,7 +83,10 @@ class Spectrum(Spectrum1D):
             Maximium wavelength of the model spectrum.
 
         model_grid : str, optional
-            Name of the model grid. Only `phoenix` is currently supported.
+            Name of the model grid.
+
+        verbose: bool, optional
+            Print details for debugging.
 
         Returns
         -------
@@ -276,6 +279,56 @@ class Spectrum(Spectrum1D):
 
             else:
                 wave_lib, flux = load_flux_from_h5(teff, logg, feh, alpha)
+
+        elif self.model_grid in ["newera_gaia", "newera_jwst", "newera_lowres"]:
+            grid_name = self.model_grid
+            lib_wave_unit = u.nm
+            lib_flux_unit = u.W / (u.m**2 * u.nm)
+
+            teff_in_grid = teff in self.grid_teffs
+            logg_in_grid = logg in self.grid_loggs
+            feh_in_grid = feh in self.grid_fehs
+            model_in_grid = all([teff_in_grid, logg_in_grid, feh_in_grid])
+            alpha_in_grid = alpha in self.grid_points.get("grid_alphas", [0.0])
+
+            def load_flux(teff_, logg_, feh_, alpha_=0.0):
+                return utils.load_newera_flux_array(
+                    teff_, logg_, feh_, alpha_, grid_name
+                )
+
+            def load_wave(teff_, logg_, feh_, alpha_=0.0):
+                return utils.load_newera_wavelength_array(
+                    teff_, logg_, feh_, alpha_, grid_name
+                )
+
+            if not model_in_grid:
+                teff_bds = utils.find_bounds(self.grid_teffs, teff)
+                logg_bds = utils.find_bounds(self.grid_loggs, logg)
+                feh_bds = utils.find_bounds(self.grid_fehs, feh)
+
+                wave_lib = load_wave(teff_bds[0], logg_bds[0], feh_bds[0], alpha)
+                c000 = load_flux(teff_bds[0], logg_bds[0], feh_bds[0], alpha)
+                c100 = load_flux(teff_bds[1], logg_bds[0], feh_bds[0], alpha)
+                c010 = load_flux(teff_bds[0], logg_bds[1], feh_bds[0], alpha)
+                c110 = load_flux(teff_bds[1], logg_bds[1], feh_bds[0], alpha)
+                c001 = load_flux(teff_bds[0], logg_bds[0], feh_bds[1], alpha)
+                c101 = load_flux(teff_bds[1], logg_bds[0], feh_bds[1], alpha)
+                c011 = load_flux(teff_bds[0], logg_bds[1], feh_bds[1], alpha)
+                c111 = load_flux(teff_bds[1], logg_bds[1], feh_bds[1], alpha)
+
+                c00 = utils.interpolate([c000, c100], teff_bds, teff)
+                c10 = utils.interpolate([c010, c110], teff_bds, teff)
+                c01 = utils.interpolate([c001, c101], teff_bds, teff)
+                c11 = utils.interpolate([c011, c111], teff_bds, teff)
+
+                c0 = utils.interpolate([c00, c10], logg_bds, logg)
+                c1 = utils.interpolate([c01, c11], logg_bds, logg)
+
+                flux = utils.interpolate([c0, c1], feh_bds, feh)
+
+            else:
+                wave_lib = load_wave(teff, logg, feh, alpha)
+                flux = load_flux(teff, logg, feh, alpha)
 
         elif self.model_grid == "drift-phoenix":
             # Only works if the user has already cached the DRIFT-PHOENIX model grid
@@ -917,7 +970,7 @@ class SpectralGrid(object):
             The spectral resolution.
 
         model_grid : str, optional
-            Name of the model grid. Only `phoenix` is currently supported.
+            Name of the model grid.
         """
         # First check that the model_grid is valid.
         self.model_grid = model_grid.lower()
@@ -980,7 +1033,11 @@ class SpectralGrid(object):
                 fluxes[teff][logg] = {}
                 for feh in self.fehs:
                     spec = Spectrum.from_grid(
-                        teff, logg, feh, model_grid=self.model_grid, **kwargs
+                        teff,
+                        logg,
+                        feh,
+                        model_grid=self.model_grid,
+                        **kwargs,
                     )
 
                     # Set spectral resolution if specified

--- a/src/speclib/photometry.py
+++ b/src/speclib/photometry.py
@@ -42,7 +42,6 @@ class Filter(object):
         response_path = files("speclib.data.filters") / response_file
         self.response = self._load_response(response_path)
 
-
     def _get_filter_data(self, name):
         """Return the row of filter metadata corresponding to the given name."""
         filters_path = files("speclib.data.filters") / "filters.ecsv"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,4 +2,6 @@ import sys
 import os
 
 # Add the `src/` directory to sys.path so `speclib` is importable
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
+)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,6 +2,7 @@ from speclib import Spectrum
 import astropy.units as u
 import numpy as np
 
+
 def test_spectrum_basic():
     wave = np.linspace(5000, 6000, 100) * u.AA
     flux = np.ones_like(wave.value) * u.erg / u.s / u.cm**2 / u.AA
@@ -9,6 +10,7 @@ def test_spectrum_basic():
 
     assert spec.wavelength.unit == u.AA
     assert spec.flux.unit.is_equivalent(u.erg / u.s / u.cm**2 / u.AA)
+
 
 def test_spectrum_resample():
     wave = np.linspace(5000, 6000, 100) * u.AA

--- a/tests/test_photometry.py
+++ b/tests/test_photometry.py
@@ -2,10 +2,12 @@ from speclib import Spectrum, Filter, apply_filter
 import numpy as np
 import astropy.units as u
 
+
 def test_filter_initialization():
     f = Filter("2MASS J")
     assert f.name == "2MASS J"
     assert hasattr(f, "response")
+
 
 def test_apply_filter_succeeds():
     wave = np.linspace(11000, 13500, 100) * u.AA
@@ -14,4 +16,6 @@ def test_apply_filter_succeeds():
     filt = Filter("2MASS J")
 
     result = apply_filter(spec, filt)
-    assert result.unit.is_equivalent(u.erg / u.s / u.cm**2 / u.AA)  # might change later
+    assert result.unit.is_equivalent(
+        u.erg / u.s / u.cm**2 / u.AA
+    )  # might change later

--- a/tests/test_sed.py
+++ b/tests/test_sed.py
@@ -1,5 +1,6 @@
 from speclib import Spectrum, Filter, SED
 
+
 def test_sed_from_spectrum():
     spec = Spectrum.from_grid(4000, 4.5, 0.0)
     filt = Filter("2MASS J")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 from speclib.utils import nearest
 
+
 def test_nearest_simple():
     arr = [10, 20, 30]
     val = 19


### PR DESCRIPTION
This PR implements support for reading and loading stellar spectra from the NewEra low-resolution grids (`newera_gaia`, `newera_jwst`, and `newera_lowres`). These grids are stored in GAIA-compatible text format and require specialized parsing logic.

## Summary of changes

- Added two new utility functions:
  - `load_newera_wavelength_array()`: Reads wavelength arrays from NewEra text files.
  - `load_newera_flux_array()`: Reads flux values and handles unit conversions; currently supports only `alpha=0.0` with a warning for other values.
- Updated `Spectrum.from_grid()` in `core.py` to support loading from the NewEra grids by dispatching to the appropriate loading functions.
- Introduced robust filename formatting logic based on metallicity `z` and alpha enhancement.
- Added warnings when attempting to load unsupported alpha values.
- Added a test to confirm that the new functionality works as expected for a range of valid parameters.
- Bumped version to `0.1.0-beta.4`.

## Notes

- Currently, only `alpha=0.0` is fully supported. Loading non-zero alpha files will trigger a warning and may not succeed depending on the file format consistency.
- The header format used by NewEra grids differs from other supported models and required custom parsing, especially to infer the wavelength grid from the first line.

## Checklist

- [x] All tests pass (`poetry run tox`)
- [x] Version bumped to `0.1.0-beta.4`
- [x] Changelog updated
- [x] Merged with latest `main`

Closes #16.
