### PR TITLE
🔀 Pull request: Fix NewEra grid loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- Automatically trigger NewEra tarball download when loading a wavelength array for the first time.
+  `load_newera_wavelength_array()` now calls `download_newera_grid()` if the expected `.txt` file is missing.
+
+---
+
 ## [0.1.0-beta.4] - 2025-05-30
 
 ### Added

--- a/src/speclib/utils.py
+++ b/src/speclib/utils.py
@@ -17,6 +17,7 @@ from urllib.error import URLError
 __all__ = [
     "download_file",
     "download_phoenix_grid",
+    "download_newera_grid",
     "find_bounds",
     "interpolate",
     "load_flux_array",
@@ -435,6 +436,11 @@ def load_newera_wavelength_array(
 
     filepath = grid_dir / fname
 
+    # Trigger download and extraction if file is missing
+    if not filepath.exists():
+        download_newera_grid(grid_name)
+
+    # Raise error if the file still doesn't exist.
     if not filepath.exists():
         raise FileNotFoundError(f"File not found: {filepath}")
 


### PR DESCRIPTION
### Summary

This PR fixes a bug where NewEra grid tarballs were not being automatically downloaded when loading a spectrum for the first time, if the wavelength array was accessed before the flux.

### Background

Previously, `speclib` triggered tarball downloads only inside `load_newera_flux_array()`. However, `Spectrum.from_grid()` often accesses the wavelength array first, causing a `FileNotFoundError` if the corresponding `.txt` file had not already been extracted.

### Fix

This PR updates `utils.load_newera_wavelength_array()` to call `download_newera_grid(grid_name)` when the expected file is missing. This ensures that the `.tar.gz` archive is downloaded and extracted on first access, whether the user loads the wavelength or flux first.

### Changes

* Modified `utils.load_newera_wavelength_array()` to check for file presence and call `download_newera_grid()` if missing.
* Added `download_newera_grid` to `__all__` for clarity and consistency.

### Related Issue

Closes #22

### Changelog

Added under `## [Unreleased]`:

```markdown
### Fixed
- Automatically trigger NewEra tarball download when loading a wavelength array for the first time.
  `load_newera_wavelength_array()` now calls `download_newera_grid()` if the expected `.txt` file is missing.
```

### Reviewer Notes

* No impact on existing users with fully cached grids.
* This should eliminate first-use errors for NewEra grids.
