### PR TITLE
Fix docstring typo

### DIFF
--- a/src/speclib/photometry.py
+++ b/src/speclib/photometry.py
@@ -140,7 +140,7 @@ class SEDGrid(object):
         The lower and upper bounds of the model [Fe/H] to load.
 
     wavelength : `~astropy.units.Quantity`
-        Efffective wavelengths of the SED grid.
+        Effective wavelengths of the SED grid.
 
     bandwidth : `~astropy.units.Quantity`
         Bandwidths of the interpolated SED grid.


### PR DESCRIPTION
## Summary
- fix typo in photometry SEDGrid docstring

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'astropy')*

------
https://chatgpt.com/codex/tasks/task_e_685d63485108833091418f834064b531