### PR TITLE
Use local SPHINX spectra in tests

### DIFF
--- a/src/speclib/core.py
+++ b/src/speclib/core.py
@@ -390,32 +390,32 @@ class Spectrum(Spectrum1D):
                 fname111 = fname_str.format(teff_bds[1], logg_bds[1], feh_bds[1])
 
                 if not fname000 == fname100:
-                    c000 = np.loadtxt(cache_dir + fname000, unpack=True, usecols=1)
-                    c100 = np.loadtxt(cache_dir + fname100, unpack=True, usecols=1)
+                    wave_lib, c000 = load_wave_flux(fname000)
+                    _, c100 = load_wave_flux(fname100)
                     c00 = utils.interpolate([c000, c100], teff_bds, teff)
                 else:
-                    c00 = np.loadtxt(cache_dir + fname000, unpack=True, usecols=1)
+                    wave_lib, c00 = load_wave_flux(fname000)
 
                 if not fname010 == fname110:
-                    c010 = np.loadtxt(cache_dir + fname010, unpack=True, usecols=1)
-                    c110 = np.loadtxt(cache_dir + fname110, unpack=True, usecols=1)
+                    _, c010 = load_wave_flux(fname010)
+                    _, c110 = load_wave_flux(fname110)
                     c10 = utils.interpolate([c010, c110], teff_bds, teff)
                 else:
-                    c10 = np.loadtxt(cache_dir + fname010, unpack=True, usecols=1)
+                    _, c10 = load_wave_flux(fname010)
 
                 if not fname001 == fname101:
-                    c001 = np.loadtxt(cache_dir + fname001, unpack=True, usecols=1)
-                    c101 = np.loadtxt(cache_dir + fname101, unpack=True, usecols=1)
+                    _, c001 = load_wave_flux(fname001)
+                    _, c101 = load_wave_flux(fname101)
                     c01 = utils.interpolate([c001, c101], teff_bds, teff)
                 else:
-                    c01 = np.loadtxt(cache_dir + fname001, unpack=True, usecols=1)
+                    _, c01 = load_wave_flux(fname001)
 
                 if not fname011 == fname111:
-                    c011 = np.loadtxt(cache_dir + fname011, unpack=True, usecols=1)
-                    c111 = np.loadtxt(cache_dir + fname111, unpack=True, usecols=1)
+                    _, c011 = load_wave_flux(fname011)
+                    _, c111 = load_wave_flux(fname111)
                     c11 = utils.interpolate([c011, c111], teff_bds, teff)
                 else:
-                    c11 = np.loadtxt(cache_dir + fname011, unpack=True, usecols=1)
+                    _, c11 = load_wave_flux(fname011)
 
                 if not fname000 == fname010:
                     c0 = utils.interpolate([c00, c10], logg_bds, logg)
@@ -430,9 +430,9 @@ class Spectrum(Spectrum1D):
                     flux = c0
 
             elif model_in_grid:
-                # Load the flux array
+                # Load the wavelength and flux arrays
                 fname = fname_str.format(teff, logg, feh)
-                flux = np.loadtxt(cache_dir + fname, unpack=True, usecols=1)
+                wave_lib, flux = load_wave_flux(fname)
 
         elif self.model_grid == "nextgen-solar":
             # Only works if the user has already cached the NextGen model grid
@@ -538,11 +538,9 @@ class Spectrum(Spectrum1D):
             # fname_str = "Teff_{:04.1f}_logg_{:0.2f}_logZ_{:+0.2f}_CtoO_{:0.1f}_spectra.txt"
             fname_str = "Teff_{:04.1f}_logg_{:0.2f}_logZ_{:+0.2f}_CtoO_0.5_spectra.txt"
 
-            # Load the wavelength array
-            wave_local_path = os.path.join(
-                cache_dir, "Teff_2000.0_logg_4.00_logZ_-0.25_CtoO_0.3_spectra.txt"
-            )
-            wave_lib = np.loadtxt(wave_local_path, unpack=True, usecols=0)
+            def load_wave_flux(fname):
+                wave, flux = np.loadtxt(cache_dir + fname, unpack=True)
+                return wave, flux
 
             teff_in_grid = teff in self.grid_teffs
             logg_in_grid = logg in self.grid_loggs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,30 @@
 import sys
 import os
+from pathlib import Path
+import shutil
+import pytest
 
 # Add the `src/` directory to sys.path so `speclib` is importable
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
-)
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+
+@pytest.fixture(scope="session", autouse=True)
+def local_sphinx_cache(tmp_path_factory):
+    """Provide a local SPHINX cache so tests avoid network access."""
+    tmp_home = tmp_path_factory.mktemp("speclib_home")
+    cache_dir = tmp_home / ".speclib" / "libraries" / "sphinx"
+    cache_dir.mkdir(parents=True)
+
+    data_dir = Path(__file__).parent / "data" / "sphinx"
+    for fname in data_dir.iterdir():
+        shutil.copy(fname, cache_dir / fname.name)
+
+    old_home = os.environ.get("HOME")
+    os.environ["HOME"] = str(tmp_home)
+    try:
+        yield
+    finally:
+        if old_home is not None:
+            os.environ["HOME"] = old_home
+        else:
+            os.environ.pop("HOME", None)

--- a/tests/test_interpolation_toggle.py
+++ b/tests/test_interpolation_toggle.py
@@ -8,29 +8,29 @@ from speclib.core import SpectralGrid, BinnedSpectralGrid
 @pytest.fixture(scope="module")
 def spectral_grid():
     return SpectralGrid(
-        teff_bds=(3700, 3900),
-        logg_bds=(4.5, 5.0),
+        teff_bds=(3000, 3000),
+        logg_bds=(4.0, 4.5),
         feh_bds=(0.0, 0.0),
-        model_grid="phoenix",
+        model_grid="sphinx",
         wavelength=np.linspace(1.0, 2.0, 100) * u.micron,
     )
 
 
 def test_spectral_grid_get_spectrum_nearest_exact_match(spectral_grid):
-    spec_interp = spectral_grid.get_spectrum(3800, 4.5, 0.0, interpolate=True)
-    spec_nearest = spectral_grid.get_spectrum(3800, 4.5, 0.0, interpolate=False)
+    spec_interp = spectral_grid.get_spectrum(3000, 4.0, 0.0, interpolate=True)
+    spec_nearest = spectral_grid.get_spectrum(3000, 4.0, 0.0, interpolate=False)
     np.testing.assert_allclose(spec_interp.value, spec_nearest.value, rtol=1e-5)
 
 
 def test_spectral_grid_get_spectrum_nearest_off_grid(spectral_grid):
-    spec_nearest = spectral_grid.get_spectrum(3820, 4.5, 0.0, interpolate=False)
-    spec_base = spectral_grid.get_spectrum(3800, 4.5, 0.0, interpolate=False)
+    spec_nearest = spectral_grid.get_spectrum(3000, 4.25, 0.0, interpolate=False)
+    spec_base = spectral_grid.get_spectrum(3000, 4.0, 0.0, interpolate=False)
     assert np.allclose(spec_nearest.value, spec_base.value)
 
 
 def test_interpolated_vs_nearest_spectrum_differ(spectral_grid):
-    spec_interp = spectral_grid.get_spectrum(3820, 4.5, 0.0, interpolate=True)
-    spec_nearest = spectral_grid.get_spectrum(3820, 4.5, 0.0, interpolate=False)
+    spec_interp = spectral_grid.get_spectrum(3000, 4.25, 0.0, interpolate=True)
+    spec_nearest = spectral_grid.get_spectrum(3000, 4.25, 0.0, interpolate=False)
     assert not np.allclose(spec_interp.value, spec_nearest.value)
 
 
@@ -39,16 +39,16 @@ def test_binned_grid_get_spectrum_nearest_off_grid(spectral_grid):
     width = np.full_like(center, fill_value=(center[1] - center[0]))
 
     grid = BinnedSpectralGrid(
-        teff_bds=(3700, 3900),
-        logg_bds=(4.5, 5.0),
+        teff_bds=(3000, 3000),
+        logg_bds=(4.0, 4.5),
         feh_bds=(0.0, 0.0),
         center=center,
         width=width,
-        model_grid="phoenix",
+        model_grid="sphinx",
         wavelength=spectral_grid.wavelength,
     )
 
-    spec_interp = grid.get_spectrum(3820, 4.5, 0.0, interpolate=True)
-    spec_nearest = grid.get_spectrum(3820, 4.5, 0.0, interpolate=False)
+    spec_interp = grid.get_spectrum(3000, 4.25, 0.0, interpolate=True)
+    spec_nearest = grid.get_spectrum(3000, 4.25, 0.0, interpolate=False)
 
     assert not np.allclose(spec_interp.value, spec_nearest.value)

--- a/tests/test_sed.py
+++ b/tests/test_sed.py
@@ -2,7 +2,7 @@ from speclib import Spectrum, Filter, SED
 
 
 def test_sed_from_spectrum():
-    spec = Spectrum.from_grid(4000, 4.5, 0.0)
+    spec = Spectrum.from_grid(3000, 4.0, 0.0, model_grid="sphinx")
     filt = Filter("2MASS J")
     sed = SED(spec, [filt])
     assert sed.flux.unit.is_equivalent(filt.zeropoint_flux.unit)


### PR DESCRIPTION
## Summary
- copy sample SPHINX spectra to a temporary cache during tests
- load SPHINX wavelength data directly from each spectrum file

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'astropy')*

------
https://chatgpt.com/codex/tasks/task_e_685d79111ef48330ad403bd625f543c7