### PR TITLE
Try to update dependencies?

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ pip install git+https://github.com/brackham/speclib.git
 * Python 3.9 to 3.11
 * [astropy](https://www.astropy.org/)
 * [specutils](https://specutils.readthedocs.io/)
-* [pysynphot](https://pysynphot.readthedocs.io/)
+* [synphot](https://synphot.readthedocs.io/)
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,12 +11,12 @@ authors = [
 ]
 license = { text = "MIT" }
 readme = "README.md"
-requires-python = ">=3.9,<3.12"
+requires-python = ">=3.9"
 dependencies = [
   "astropy>=6.0.0,<8.0.0",
   "specutils (>=1.9.1,<2.0.0)",
-  "pysynphot>=2.0.0,<3.0.0",
-  "numpy<2.0",
+  "synphot",
+  "numpy",
   "h5py (>=3.13.0,<4.0.0)",
   "pooch (>=1.8.2,<2.0.0)",
   "tqdm (>=4.67.1,<5.0.0)",

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,3 @@
 [pytest]
 testpaths = tests
 python_files = test_*.py
-filterwarnings =
-    ignore::DeprecationWarning:pysynphot.*

--- a/src/speclib/photometry.py
+++ b/src/speclib/photometry.py
@@ -386,7 +386,7 @@ def apply_filter(spec, filt):
     except ValueError:
         filt.resample(spec.wavelength)
         filtered_flux = spec.flux * filt.response.flux
-    integrated_flux = np.trapz(filtered_flux, spec.wavelength) / filt.bandwidth
+    integrated_flux = np.trapezoid(filtered_flux, spec.wavelength) / filt.bandwidth
 
     return integrated_flux
 


### PR DESCRIPTION
Hi @brackham ,

@varriero and I both just tried testing out `speclib`, and it worked swell! However, we both had to create new conda environments because of the `python` + `numpy` + `pysynphot` requirements. 

For whatever tiny bit it's worth, here's a very quick and dirty and probably slightly unreliable attempt at updating those, mostly through trial and error. It *maybe* does some of the stuff in #39 , but I wouldn't trust it to be comprehensive. I just got it to the point of making your tests work and the [gist](https://gist.github.com/brackham/b6db1fd0bc680b781d360d4161d0c5e8) you sent @catrionamurray.

For `numpy`, the main thing I saw was `np.trapz` -> `np.trapezoid`. 

For getting to `python=3.13`, it had to replace `pysynphot` with `synphot`. It *mostly* worked with a find and replace, except I had to do nasty and I'm not sure 100% accurate things with units in your `Spectrum.resample`.  I don't know that I'd actually advocate for merging this Pull Request in, but maybe there's a hint of something or two that might be helpful for you when you go through it yourself? 

Thanks!!!




It runs on my laptop in an environment with
```
name: current-speclib
channels:
  - http://astroconda.gemini.edu/public
  - conda-forge
  - https://repo.anaconda.com/pkgs/main
  - https://repo.anaconda.com/pkgs/r
dependencies:
  - appnope=0.1.4=pyhd8ed1ab_1
  - asttokens=3.0.0=pyhd8ed1ab_1
  - brotli=1.1.0=h5505292_3
  - brotli-bin=1.1.0=h5505292_3
  - bzip2=1.0.8=h99b78c6_7
  - ca-certificates=2025.8.3=hbd8a1cb_0
  - comm=0.2.3=pyhe01879c_0
  - contourpy=1.3.3=py313hc50a443_1
  - cycler=0.12.1=pyhd8ed1ab_1
  - debugpy=1.8.16=py313hab38a8b_0
  - decorator=5.2.1=pyhd8ed1ab_0
  - exceptiongroup=1.3.0=pyhd8ed1ab_0
  - executing=2.2.0=pyhd8ed1ab_0
  - fonttools=4.59.0=py313ha0c97b7_0
  - freetype=2.13.3=hce30654_1
  - icu=75.1=hfee45f7_0
  - importlib-metadata=8.7.0=pyhe01879c_1
  - ipykernel=6.30.1=pyh92f572d_0
  - ipython=9.4.0=pyhfa0c392_0
  - ipython_pygments_lexers=1.1.1=pyhd8ed1ab_0
  - jedi=0.19.2=pyhd8ed1ab_1
  - jupyter_client=8.6.3=pyhd8ed1ab_1
  - jupyter_core=5.8.1=pyh31011fe_0
  - kiwisolver=1.4.8=py313h0ebd0e5_1
  - krb5=1.21.3=h237132a_0
  - lcms2=2.17=h7eeda09_0
  - lerc=4.0.0=hd64df32_1
  - libblas=3.9.0=34_h10e41b3_openblas
  - libbrotlicommon=1.1.0=h5505292_3
  - libbrotlidec=1.1.0=h5505292_3
  - libbrotlienc=1.1.0=h5505292_3
  - libcblas=3.9.0=34_hb3479ef_openblas
  - libcxx=20.1.8=hf598326_1
  - libdeflate=1.24=h5773f1b_0
  - libedit=3.1.20250104=pl5321hafb1f1b_0
  - libexpat=2.7.1=hec049ff_0
  - libffi=3.4.6=h1da3d7d_1
  - libfreetype=2.13.3=hce30654_1
  - libfreetype6=2.13.3=h1d14073_1
  - libgfortran=15.1.0=hfdf1602_0
  - libgfortran5=15.1.0=hb74de2c_0
  - libjpeg-turbo=3.1.0=h5505292_0
  - liblapack=3.9.0=34_hc9a63f6_openblas
  - liblzma=5.8.1=h39f12f2_2
  - libmpdec=4.0.0=h5505292_0
  - libopenblas=0.3.30=openmp_h60d53f8_1
  - libpng=1.6.50=h280e0eb_1
  - libsodium=1.0.20=h99b78c6_0
  - libsqlite=3.50.4=h4237e3c_0
  - libtiff=4.7.0=h2f21f7c_5
  - libwebp-base=1.6.0=h07db88b_0
  - libxcb=1.17.0=hdb1d25a_0
  - libzlib=1.3.1=h8359307_2
  - llvm-openmp=20.1.8=hbb9b287_1
  - matplotlib=3.10.5=py313h39782a4_0
  - matplotlib-base=3.10.5=py313h919948c_0
  - matplotlib-inline=0.1.7=pyhd8ed1ab_1
  - munkres=1.1.4=pyhd8ed1ab_1
  - ncurses=6.5=h5e97a16_3
  - nest-asyncio=1.6.0=pyhd8ed1ab_1
  - numpy=2.3.2=py313h674b998_0
  - openjpeg=2.5.3=h889cd5d_1
  - openssl=3.5.2=he92f556_0
  - packaging=25.0=pyh29332c3_1
  - parso=0.8.4=pyhd8ed1ab_1
  - pexpect=4.9.0=pyhd8ed1ab_1
  - pickleshare=0.7.5=pyhd8ed1ab_1004
  - pillow=11.3.0=py313hb37fac4_0
  - pip=25.2=pyh145f28c_0
  - platformdirs=4.3.8=pyhe01879c_0
  - prompt-toolkit=3.0.51=pyha770c72_0
  - psutil=7.0.0=py313h90d716c_0
  - pthread-stubs=0.4=hd74edd7_1002
  - ptyprocess=0.7.0=pyhd8ed1ab_1
  - pure_eval=0.2.3=pyhd8ed1ab_1
  - pygments=2.19.2=pyhd8ed1ab_0
  - pyparsing=3.2.3=pyhe01879c_2
  - python=3.13.5=hf3f3da0_102_cp313
  - python-dateutil=2.9.0.post0=pyhe01879c_2
  - python_abi=3.13=8_cp313
  - pyzmq=27.0.1=py313h330de61_0
  - qhull=2020.2=h420ef59_5
  - readline=8.2=h1d1bf99_2
  - six=1.17.0=pyhe01879c_1
  - stack_data=0.6.3=pyhd8ed1ab_1
  - tk=8.6.13=h892fb3f_2
  - tornado=6.5.1=py313h90d716c_0
  - traitlets=5.14.3=pyhd8ed1ab_1
  - typing_extensions=4.14.1=pyhe01879c_0
  - tzdata=2025b=h78e105d_0
  - wcwidth=0.2.13=pyhd8ed1ab_1
  - xorg-libxau=1.0.12=h5505292_0
  - xorg-libxdmcp=1.1.5=hd74edd7_0
  - zeromq=4.3.5=hc1bb282_7
  - zipp=3.23.0=pyhd8ed1ab_0
  - zstd=1.5.7=h6491c7d_2
  - pip:
      - asdf==4.3.0
      - asdf-astropy==0.8.0
      - asdf-coordinates-schemas==0.4.0
      - asdf-standard==1.3.0
      - asdf-transform-schemas==0.6.0
      - asdf-wcs-schemas==0.5.0
      - astropy==7.1.0
      - astropy-iers-data==0.2025.8.4.0.42.59
      - attrs==25.3.0
      - beautifulsoup4==4.13.4
      - certifi==2025.8.3
      - charset-normalizer==3.4.2
      - gwcs==0.25.2
      - h5py==3.14.0
      - idna==3.10
      - iniconfig==2.1.0
      - jmespath==1.0.1
      - ndcube==2.3.2
      - pluggy==1.6.0
      - pooch==1.8.2
      - pyerfa==2.0.1.5
      - pysynphot==2.0.0
      - pytest==8.4.1
      - pyyaml==6.0.2
      - requests==2.32.4
      - scipy==1.16.1
      - semantic-version==2.10.0
      - soupsieve==2.7
      - speclib==0.1.0b6
      - specutils==1.20.3
      - synphot==1.6.0
      - tqdm==4.67.1
      - urllib3==2.5.0
prefix: /Users/zabe0091/miniconda3/envs/current-speclib
```