### PR TITLE
Lazy extract NewEra tarballs by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased]
+## [0.1.0b11] - 2026-01-28
 
 ### Added
 
@@ -24,6 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   explicitly unpack the full grid.
 - NewEra tar extraction now resolves the requested member directly (with cached
   name lookups) to avoid repeated full scans of tar members.
+
+### Related issues
+
+- Closes #61: Avoid unpacking full NewEra tarballs by default; extract only required files
+
 
 ## [0.1.0b10] - 2025-10-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   extract only the required `.txt` file on demand.
 - `download_newera_grid()` now supports `extract="all"` for users who want to
   explicitly unpack the full grid.
+- NewEra tar extraction now resolves the requested member directly (with cached
+  name lookups) to avoid repeated full scans of tar members.
 
 ## [0.1.0b10] - 2025-10-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `download_newera_grid()` convenience helper that downloads and optionally
   refreshes NewEra model grids (`newera_gaia`, `newera_jwst`, `newera_lowres`) while
   clearing outdated files when `overwrite=True`.
+- Documented NewEra tarball caching with on-demand extraction in `README.md`.
+
+### Changed
+
+- NewEra grid downloads now cache tarballs without unpacking by default; loaders
+  extract only the required `.txt` file on demand.
+- `download_newera_grid()` now supports `extract="all"` for users who want to
+  explicitly unpack the full grid.
 
 ## [0.1.0b10] - 2025-10-27
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,23 @@ Set the ``SPECLIB_LIBRARY_PATH`` environment variable or call
 ``speclib.utils.set_library_root("/path/to/cache")`` to use a different
 location.
 
+### NewEra grid caching and extraction
+
+NewEra grid downloads now keep the tarball cached without unpacking by default.
+When a specific metallicity file is needed, it is extracted on demand from the
+cached archive. To explicitly extract the full grid (for offline usage or bulk
+access), use the ``extract="all"`` option:
+
+```python
+from speclib.utils import download_newera_grid
+
+# Cache the tarball only (default behavior)
+download_newera_grid("newera_jwst")
+
+# Extract all members from the tarball
+download_newera_grid("newera_jwst", extract="all")
+```
+
 ---
 
 ## License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "speclib"
-version = "0.1.0b10"
+version = "0.1.0b11"
 description = "Tools for working with stellar spectral libraries."
 authors = [
   { name = "Benjamin V. Rackham" }

--- a/src/speclib/utils.py
+++ b/src/speclib/utils.py
@@ -47,6 +47,7 @@ NEWERA_TARBALLS: dict[str, str] = {
 
 _LIBRARY_ROOT: Path | None = None
 _NEWERA_INDEX_CACHE: dict[tuple[Path, str], dict] = {}
+_NEWERA_TAR_MEMBER_CACHE: dict[Path, dict[str, str]] = {}
 
 _NEWERA_MODEL_LINE_RE = re.compile(
     r"(?P<filename>"
@@ -385,15 +386,23 @@ def extract_member_from_tar(
     """
     extract_dir.mkdir(parents=True, exist_ok=True)
     with tarfile.open(tar_path, "r:*") as tar:
-        for member in tar.getmembers():
-            if Path(member.name).name == member_name:
-                print(f"📦 Extracting: {member.name}")
-                tar.extract(member, path=extract_dir)
-                return extract_dir / Path(member.name).name
+        try:
+            member = tar.getmember(member_name)
+        except KeyError:
+            cached = _NEWERA_TAR_MEMBER_CACHE.get(tar_path)
+            if cached is None:
+                cached = {Path(name).name: name for name in tar.getnames()}
+                _NEWERA_TAR_MEMBER_CACHE[tar_path] = cached
+            full_name = cached.get(member_name)
+            if full_name is None:
+                raise FileNotFoundError(
+                    f"Member '{member_name}' not found in archive: {tar_path}"
+                )
+            member = tar.getmember(full_name)
 
-    raise FileNotFoundError(
-        f"Member '{member_name}' not found in archive: {tar_path}"
-    )
+        print(f"📦 Extracting: {member.name}")
+        tar.extract(member, path=extract_dir)
+        return extract_dir / Path(member.name).name
 
 
 def extract_missing_txt_files(tar_path: Path, extract_dir: Path) -> None:

--- a/src/speclib/utils.py
+++ b/src/speclib/utils.py
@@ -282,25 +282,32 @@ def _clear_directory(path: Path) -> None:
 
 
 def download_newera_grid(
-    grid_name: str, extract: bool = True, overwrite: bool = False
+    grid_name: str,
+    extract: bool | str = False,
+    overwrite: bool = False,
+    library_root: str | Path | None = None,
 ) -> Path:
     """
-    Download and extract a NewEra tarball if not already cached.
+    Download a NewEra tarball if not already cached.
 
     Parameters
     ----------
     grid_name : str
         One of "newera_gaia", "newera_lowres", or "newera_jwst".
-    extract : bool, optional
-        If True, extract the tarball after download. Default is True.
+    extract : bool or {"missing", "all"}, optional
+        Controls extraction behavior. ``False`` (default) keeps the tarball cached
+        without unpacking. ``True`` or ``"missing"`` extracts only missing ``.txt``
+        members. ``"all"`` extracts every member in the archive.
     overwrite : bool, optional
         If True, remove any existing files in the cache directory and re-download the
         tarball. Default is False.
+    library_root : str or Path, optional
+        Base cache directory. Defaults to :func:`get_library_root`.
 
     Returns
     -------
     Path
-        Path to the extracted directory (e.g., ~/.speclib/libraries/newera_jwst).
+        Path to the cached directory (e.g., ~/.speclib/libraries/newera_jwst).
 
     Note
     ----
@@ -313,8 +320,25 @@ def download_newera_grid(
             f"Unknown grid_name '{grid_name}'. Must be one of {list(NEWERA_TARBALLS.keys())}"
         )
 
+    extract_mode = "none"
+    if isinstance(extract, str):
+        extract_mode = extract.lower()
+    elif extract:
+        extract_mode = "missing"
+
+    if extract_mode not in {"none", "missing", "all"}:
+        raise ValueError(
+            "extract must be False, True, 'missing', or 'all' "
+            f"(received: {extract})"
+        )
+
+    if library_root is None:
+        library_root = get_library_root()
+    else:
+        library_root = Path(library_root)
+
     # Cache location: ~/.speclib/libraries/{grid_name}/  (or custom path)
-    cache_dir = get_library_root() / grid_name
+    cache_dir = library_root / grid_name
     cache_dir.mkdir(parents=True, exist_ok=True)
     record_id = get_newera_record_id()
 
@@ -334,11 +358,42 @@ def download_newera_grid(
         print(f"✅ Using cached NewEra archive: {tar_path.name}")
 
     # Extract tarball if requested
-    if extract:
+    if extract_mode != "none":
         print(f"🗂 Extracting archive to: {cache_dir}")
-        extract_missing_txt_files(tar_path, cache_dir)
+        if extract_mode == "all":
+            extract_all_members(tar_path, cache_dir)
+        else:
+            extract_missing_txt_files(tar_path, cache_dir)
 
     return cache_dir
+
+
+def extract_member_from_tar(
+    tar_path: Path, member_name: str, extract_dir: Path
+) -> Path:
+    """
+    Extract a single tar member into extract_dir.
+
+    Parameters
+    ----------
+    tar_path : Path
+        Path to the tar archive.
+    member_name : str
+        The member filename to extract (basename match).
+    extract_dir : Path
+        Directory to extract into.
+    """
+    extract_dir.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(tar_path, "r:*") as tar:
+        for member in tar.getmembers():
+            if Path(member.name).name == member_name:
+                print(f"📦 Extracting: {member.name}")
+                tar.extract(member, path=extract_dir)
+                return extract_dir / Path(member.name).name
+
+    raise FileNotFoundError(
+        f"Member '{member_name}' not found in archive: {tar_path}"
+    )
 
 
 def extract_missing_txt_files(tar_path: Path, extract_dir: Path) -> None:
@@ -359,6 +414,38 @@ def extract_missing_txt_files(tar_path: Path, extract_dir: Path) -> None:
                 if not target_file.exists():
                     print(f"📦 Extracting: {member.name}")
                     tar.extract(member, path=extract_dir)
+
+
+def extract_all_members(tar_path: Path, extract_dir: Path) -> None:
+    """
+    Extract all tar members into extract_dir.
+
+    Parameters
+    ----------
+    tar_path : Path
+        Path to the tar archive.
+    extract_dir : Path
+        Directory to extract into.
+    """
+    with tarfile.open(tar_path, "r:*") as tar:
+        for member in tar.getmembers():
+            print(f"📦 Extracting: {member.name}")
+            tar.extract(member, path=extract_dir)
+
+
+def _ensure_newera_txt_file(
+    grid_name: str, filename: str, grid_dir: Path, library_root: Path
+) -> Path:
+    tar_path = grid_dir / NEWERA_TARBALLS[grid_name]
+    if not tar_path.exists():
+        download_newera_grid(
+            grid_name, extract=False, library_root=library_root, overwrite=False
+        )
+
+    if not tar_path.exists():
+        raise FileNotFoundError(f"NewEra archive not found: {tar_path}")
+
+    return extract_member_from_tar(tar_path, filename, grid_dir)
 
 
 def download_file(remote_path, local_path, verbose=True):
@@ -644,7 +731,8 @@ def load_newera_wavelength_array(
     Raises
     ------
     FileNotFoundError
-        If the expected file is missing.
+        If the expected file is missing and cannot be extracted from the cached
+        tarball.
     ValueError
         If a valid header is not found.
     """
@@ -683,11 +771,9 @@ def load_newera_wavelength_array(
 
     filepath = grid_dir / fname
 
-    # Trigger download and extraction if file is missing
     if not filepath.exists():
-        download_newera_grid(grid_name)
+        _ensure_newera_txt_file(grid_name, fname, grid_dir, library_root)
 
-    # Raise error if the file still doesn't exist.
     if not filepath.exists():
         raise FileNotFoundError(f"File not found: {filepath}")
 
@@ -755,6 +841,9 @@ def load_newera_flux_array(
 
     Raises
     ------
+    FileNotFoundError
+        If the expected file is missing and cannot be extracted from the cached
+        tarball.
     ValueError
         If no matching model is found in the file.
     """
@@ -786,6 +875,9 @@ def load_newera_flux_array(
         fname = f"{prefix}.{z_str}.{alpha_str}.txt"
 
     filepath = grid_dir / fname
+
+    if not filepath.exists():
+        _ensure_newera_txt_file(grid_name, fname, grid_dir, library_root)
 
     if not filepath.exists():
         raise FileNotFoundError(f"File not found: {filepath}")


### PR DESCRIPTION
### Motivation

- Avoid eagerly unpacking large NewEra tarballs into the local cache to reduce disk usage and only extract individual `.txt` members on demand.  
- Preserve an explicit opt-in for users who want the full grid unpacked for offline or bulk access.  

### Description

- Change `download_newera_grid()` signature to `download_newera_grid(grid_name, extract=False, overwrite=False, library_root=None)` and add support for `extract` modes `False | True/"missing" | "all"` (default is cache-only).  
- Add helper functions `extract_member_from_tar()`, `extract_all_members()` and `_ensure_newera_txt_file()` to extract a single member or the full archive and to ensure a requested `.txt` is present by extracting it from the cached tarball.  
- Update `load_newera_wavelength_array()` and `load_newera_flux_array()` to call `_ensure_newera_txt_file()` when the expected `.txt` is missing so files are extracted on-demand from the cached tarball.  
- Add `library_root` passthrough where appropriate and small user-facing messages when extraction/download actions occur.  
- Document the new caching/extraction behavior in `README.md` and record the change in `CHANGELOG.md`.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979d3750b288330ae8938817cb478df)