### PR TITLE
Add citation and contributor metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,38 @@
+{
+  "title": "speclib",
+  "upload_type": "software",
+  "description": "Tools for working with stellar spectral libraries.",
+  "creators": [
+    {
+      "name": "Rackham, Benjamin V.",
+      "orcid": "0000-0002-3627-1676"
+    }
+  ],
+  "contributors": [
+    {
+      "name": "Berta-Thompson, Zachory K.",
+      "type": "Other",
+      "orcid": "0000-0002-3321-4924"
+    }
+  ],
+  "license": "MIT",
+  "keywords": [
+    "astronomy",
+    "stellar spectra",
+    "spectral libraries",
+    "synthetic photometry",
+    "exoplanets"
+  ],
+  "related_identifiers": [
+    {
+      "identifier": "10.3847/1538-3881/ad5833",
+      "relation": "references",
+      "scheme": "doi"
+    },
+    {
+      "identifier": "https://github.com/brackham/speclib",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Documentation
+
+- Added citation metadata for the software and Rackham & de Wit (2024).
+- Added Zenodo creator/contributor metadata distinguishing Benjamin V. Rackham as creator and Zachory K. Berta-Thompson as contributor.
+- Added contributor-credit policy documentation.
+
 ## [0.1.0b11] - 2026-01-28
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,6 +16,7 @@ references:
         orcid: "https://orcid.org/0000-0002-3627-1676"
       - family-names: de Wit
         given-names: Julien
+        orcid: "https://orcid.org/0000-0003-2415-2191"
     title: "Toward Robust Corrections for Stellar Contamination in JWST Exoplanet Transmission Spectra"
     journal: "The Astronomical Journal"
     year: 2024

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,25 @@
+cff-version: 1.2.0
+message: "If you use speclib in published work, please cite both the archived Zenodo software release corresponding to the version used and Rackham & de Wit (2024)."
+title: "speclib"
+doi: "10.5281/zenodo.7868049"
+authors:
+  - family-names: Rackham
+    given-names: Benjamin V.
+    orcid: "https://orcid.org/0000-0002-3627-1676"
+repository-code: "https://github.com/brackham/speclib"
+license: MIT
+references:
+  - type: article
+    authors:
+      - family-names: Rackham
+        given-names: Benjamin V.
+        orcid: "https://orcid.org/0000-0002-3627-1676"
+      - family-names: de Wit
+        given-names: Julien
+    title: "Toward Robust Corrections for Stellar Contamination in JWST Exoplanet Transmission Spectra"
+    journal: "The Astronomical Journal"
+    year: 2024
+    volume: 168
+    issue: 2
+    doi: "10.3847/1538-3881/ad5833"
+    url: "https://doi.org/10.3847/1538-3881/ad5833"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Contributing to speclib
+
+Contributions are welcome and appreciated. Useful contributions include bug reports, documentation improvements, tests, bug fixes, maintenance work, and feature additions.
+
+## Contribution credit and citation metadata
+
+`speclib` distinguishes between creators/authors and contributors for citation metadata.
+
+Creators/authors are people who have made substantial intellectual, scientific, architectural, or long-term maintenance contributions to the software and who should appear in the formal citation for a release. Contributors are people who have made useful code, documentation, testing, bug-fix, maintenance, or feature contributions that should be credited but do not necessarily imply authorship of the citable software release.
+
+Pull requests, issue reports, bug fixes, documentation improvements, and small feature additions are gratefully acknowledged, but they do not automatically imply creator/authorship status on Zenodo or in `CITATION.cff`. Creator/authorship for a release is determined by the maintainer based on the nature, scope, and intellectual contribution of the work included in that release.
+
+Contributors may be credited in GitHub contributor history, release notes, the changelog, and/or Zenodo contributor metadata.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ pip install git+https://github.com/brackham/speclib.git
 
 ---
 
+## Citation
+
+If you use `speclib` in published work, please cite both:
+
+1. the archived Zenodo release corresponding to the version of `speclib` used in your work ([doi:10.5281/zenodo.7868049](https://doi.org/10.5281/zenodo.7868049)), and
+2. Rackham & de Wit (2024), [doi:10.3847/1538-3881/ad5833](https://doi.org/10.3847/1538-3881/ad5833).
+
+The Zenodo citation provides a persistent software DOI, while Rackham & de Wit (2024) describes the scientific motivation and methodology. The contribution-credit policy is described in [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+---
+
 ## Requirements
 
 * Python 3.11 to 3.13


### PR DESCRIPTION
### Motivation

- Make it explicit how to cite `speclib` by requiring users to cite both the archived Zenodo software release and the paper that describes the method, and to clarify who is credited as creator vs contributor.
- Ensure persistent software citation metadata exists (Zenodo DOI) and document contributor/creator credit policy to avoid ambiguity in releases.

### Description

- Added `CITATION.cff` (CFF v1.2.0) describing the software citation for `speclib` with DOI `10.5281/zenodo.7868049`, Benjamin V. Rackham as the software author, Rackham’s ORCID, repository URL, MIT license, and a `references` entry for Rackham & de Wit (2024). 
- Added `.zenodo.json` with `upload_type: "software"`, `creators` listing "Rackham, Benjamin V." (with ORCID), `contributors` listing "Berta-Thompson, Zachory K." (type `Other` and ORCID), related identifiers linking the paper DOI and the GitHub repository, license, description, and keywords. 
- Added `CONTRIBUTING.md` with a concise, friendly explanation of how `speclib` distinguishes creators/authors (for formal citation) from contributors and how creator/authorship for a release is determined by the maintainer. 
- Updated `README.md` to add a brief `Citation` section instructing users to cite both the Zenodo release (DOI `10.5281/zenodo.7868049`) and Rackham & de Wit (2024) (DOI `10.3847/1538-3881/ad5833`), and linked to `CONTRIBUTING.md` for contribution-credit policy. 
- Updated `CHANGELOG.md` to add an `Unreleased` top section noting the added citation metadata and contributor-credit policy; no package code changes and no version bump were made.

### Testing

- Validated `.zenodo.json` parses as JSON using `python -m json.tool .zenodo.json` and the command succeeded (`json-ok`).
- Validated `CITATION.cff` parses with Python/PyYAML using `yaml.safe_load` and confirmed `cff-version: 1.2.0` (`yaml-ok`).
- Checked for a CFF validator (`cffconvert`) and reported it is not installed in the environment, so no dedicated `cffconvert` validation was run.
- Created the `citation-metadata` branch, committed the changes, and opened the pull request titled "Add citation and contributor metadata"; the repository changes include `CITATION.cff`, `.zenodo.json`, `CONTRIBUTING.md`, the README update, and the changelog update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21f690912483308aea29f5fe5e1b83)