### PR TITLE
Remove references to Spectrum1D

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 requires-python = ">=3.11,<3.14"
 dependencies = [
   "astropy>=6.0,<8.0",
-  "specutils>=1.9.1,<2.0",
+  "specutils>=2.0",
   "synphot>=1.4,<2.0",
   "numpy>=2.0,<3.0",
   "h5py>=3.13,<4.0",

--- a/src/speclib/core.py
+++ b/src/speclib/core.py
@@ -4,7 +4,7 @@ import numpy as np
 import os
 from pathlib import Path
 import speclib.utils as utils
-from specutils import Spectrum1D
+from specutils import Spectrum
 from scipy.interpolate import NearestNDInterpolator
 
 import warnings
@@ -14,9 +14,9 @@ import synphot as sp
 __all__ = ["Spectrum", "BinnedSpectrum", "SpectralGrid", "BinnedSpectralGrid"]
 
 
-class Spectrum(Spectrum1D):
+class Spectrum(Spectrum):
     """
-    A wrapper class for `~specutils.Spectrum1D` with extended functionality for
+    A wrapper class for `~specutils.Spectrum` with extended functionality for
     working with stellar model spectra.
 
     This class adds capabilities to:
@@ -28,7 +28,7 @@ class Spectrum(Spectrum1D):
     Parameters
     ----------
     **kwargs : dict
-        Arguments passed to the base `Spectrum1D` initializer.
+        Arguments passed to the base `Spectrum` initializer.
 
     Methods
     -------

--- a/src/speclib/core.py
+++ b/src/speclib/core.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import speclib.utils as utils
 from specutils import Spectrum
 from scipy.interpolate import NearestNDInterpolator
-
+from specutils.manipulation import LinearInterpolatedResampler, SplineInterpolatedResampler
 import warnings
 
 import synphot as sp
@@ -952,7 +952,7 @@ class SpectralGrid(object):
             self.data = np.empty((0,))
             self.interpolator = None
 
-    def get_flux(self, teff, logg, feh, interpolate=True):
+    def get_flux(self, teff, logg, feh, interpolate=True, w=None, wl_interpolate_method='linear'):
         """
         Parameters
         ----------
@@ -970,6 +970,14 @@ class SpectralGrid(object):
             will be trilinearly interpolated in (Teff, logg, [Fe/H]) space. If `False`,
             the nearest available grid point will be used without interpolation.
 
+        w : array-like, optional
+            The wavelength array to interpolate the spectrum to. If `None` (default), the
+            spectrum will be the default grid's wavelength array held in ``self.wavelength``.
+
+        wl_interpolate_method : str, optional
+            The method to use for interpolating the wavelength array. Default is 'linear'.
+            Other option is 'cubic'
+
         Returns
         -------
         flux : `~astropy.units.Quantity`
@@ -985,7 +993,18 @@ class SpectralGrid(object):
         params = ["teff", "logg", "feh"]
         inputs = [teff, logg, feh]
         ranges = [self.teff_bds, self.logg_bds, self.feh_bds]
-
+        
+        if w is not None:
+            if wl_interpolate_method is 'linear':
+                interpolator_wl = LinearInterpolatedResampler
+            elif wl_interpolate_method is 'cubic':
+                interpolator_wl = SplineInterpolatedResampler
+            else:
+                raise ValueError(
+                    "Invalid wavelength interpolation method. " \
+                    "Must be either 'linear' or 'cubic'"
+                )
+            
         if not all(booleans):
             message = "Input values are out of grid range.\n\n"
             for b, p, i, r in zip(booleans, params, inputs, ranges):
@@ -1024,7 +1043,8 @@ class SpectralGrid(object):
                 raise ValueError(
                     "Interpolated flux has unexpected shape; expected a 1-D array"
                 )
-
+            if w is not None:
+                flux = interpolator_wl(Spectrum(self.wavelength, flux), w)
             return flux
 
         # If not interpolating, then just return the closest point in the grid.
@@ -1033,9 +1053,20 @@ class SpectralGrid(object):
             logg = utils.nearest(self.loggs, logg)
             feh = utils.nearest(self.fehs, feh)
 
-            return self.fluxes[teff][logg][feh]
+            if w is not None:
+                flux = interpolator_wl(Spectrum(self.wavelength, self.fluxes[teff][logg][feh]), w)
+                return flux
+            else:
+                return self.fluxes[teff][logg][feh]
+                
 
         # Otherwise, interpolate using the helper
+        if w is not None:
+            fluxer = utils.trilinear_interpolate(self.fluxes,
+                                                 (self.teffs, self.loggs, self.fehs),
+                                                 )
+            flux = interpolator_wl(Spectrum(self.wavelength, fluxer), w)
+            return flux
         return utils.trilinear_interpolate(
             self.fluxes,
             (self.teffs, self.loggs, self.fehs),

--- a/src/speclib/utils.py
+++ b/src/speclib/utils.py
@@ -1004,7 +1004,7 @@ VALID_MODELS = [
 
 # Shared grid values for all NewEra subtypes
 newera_grid = {
-    "grid_teffs": np.arange(2300, 12001, 100),
+    "grid_teffs": np.append(np.arange(2300, 8000, 100), np.arange(8000, 12001, 200)),
     "grid_loggs": np.arange(0.0, 6.1, 0.5),
     "grid_fehs": np.array([-4.0, -3.5, -3.0, -2.5, -2.0, -1.5, -1.0, -0.5, 0.0, 0.5]),
     # α-enhanced models only for -2.0 ≤ [M/H] ≤ 0.0


### PR DESCRIPTION
This is a very small pull request that seeks to remove references to Spectrum1D within the speclib package. This class was depreciated in specutils>2.0, and thus makes parts of this package depreciated when trying to use it with other specutils functions. This also allowed edits of the pyproject.toml file to no longer restrict to a very small subset of acceptable specutils versions.