### PR TITLE
Add constant spectral-resolution and resolving-power convolution APIs

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,0 +1,110 @@
+Usage
+=====
+
+Spectral resolution
+-------------------
+
+Spectral resolution and resolving power describe different broadening laws.
+Both operations return new objects and retain the input wavelength sampling;
+use :meth:`speclib.Spectrum.regularize` separately when a uniform output grid
+is desired. Returned spectra and grids contain independent copies of mutable
+axis and grid state.
+
+Constant wavelength resolution
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:meth:`speclib.Spectrum.set_spectral_resolution` applies a Gaussian whose
+full width at half maximum is constant in wavelength:
+
+.. code-block:: python
+
+   import astropy.units as u
+
+   broadened = spectrum.set_spectral_resolution(5 * u.AA)
+
+The resulting resolving power varies as
+
+.. math::
+
+   R(\lambda) = \frac{\lambda}{\Delta\lambda}.
+
+Constant resolving power
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+:meth:`speclib.Spectrum.set_spectral_resolving_power` applies constant
+resolving power:
+
+.. code-block:: python
+
+   broadened = spectrum.set_spectral_resolving_power(2700)
+
+The Gaussian width therefore varies as
+
+.. math::
+
+   \Delta\lambda(\lambda) = \frac{\lambda}{R}.
+
+The convolution is evaluated on a temporary uniform log-wavelength grid. Since
+
+.. math::
+
+   F_\lambda\,d\lambda = \lambda F_\lambda\,d\ln\lambda,
+
+the implementation convolves :math:`\lambda F_\lambda` and then divides by
+wavelength. This is the appropriate measure for preserving
+wavelength-integrated flux in the continuous, unbounded-domain limit. Finite
+boundaries and numerical remapping limit exact conservation over the returned
+interval.
+
+The stationary Gaussian is applied to flux per logarithmic wavelength
+interval. When expressed as :math:`F_\lambda`, an isolated feature therefore
+has a log-normal-like profile rather than a profile that is exactly symmetric
+in linear wavelength. This convention is intended primarily for ordinary
+astronomical resolving powers, where the distinction is small.
+
+Sampling and temporary grids
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Resolution and output sampling remain separate, but the input sampling must be
+fine enough to represent the requested result. Every input interval must
+provide at least two samples per target FWHM. For constant resolving power,
+this criterion is evaluated in log wavelength and is equivalent locally to
+requiring two samples across :math:`\lambda/R`. Under-sampled requests raise a
+``ValueError``.
+
+The internal uniform grid has at least ten samples per Gaussian FWHM and is no
+coarser than the finest input interval. Before allocating it, speclib estimates
+a conservative working set of eight float64 arrays per temporary point and
+rejects operations exceeding 512 MiB. This prevents pathological sampling or
+resolution requests from causing accidental unbounded allocations.
+
+Edges and ancillary state
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The convolution extends the endpoint value beyond each boundary. No missing
+spectrum is reconstructed outside the observed range. Features within four
+Gaussian standard deviations of a boundary can therefore lose flux and have a
+truncated line-spread function; the interior flux and resolution guarantees do
+not apply there.
+
+Masks and uncertainties require scientifically explicit propagation rules.
+Because those rules are outside the scope of these methods, spectra containing
+either are rejected instead of silently dropping or copying unsupported state.
+
+Both operations assume that the intrinsic input line width is negligible
+relative to the requested broadening. They do not deconvolve a known input
+line-spread function, and wavelength-dependent resolving power is not supported.
+
+Spectral grids
+~~~~~~~~~~~~~~
+
+:class:`speclib.SpectralGrid` provides the same two methods. They return new
+grid objects without reloading model spectra or modifying the originals:
+
+.. code-block:: python
+
+   low_resolution_grid = grid.set_spectral_resolution(5 * u.AA)
+   constant_r_grid = grid.set_spectral_resolving_power(2700)
+
+The equivalent constructor options are ``spectral_resolution`` and
+``spectral_resolving_power``. Only one may be supplied at a time.

--- a/src/speclib/core.py
+++ b/src/speclib/core.py
@@ -1,17 +1,232 @@
-import astropy.units as u
-import astropy.io.fits as fits
-import numpy as np
+import copy
 import os
 from pathlib import Path
+
+import astropy.io.fits as fits
+import astropy.units as u
+import numpy as np
 import speclib.utils as utils
-from specutils import Spectrum1D
 from scipy.interpolate import NearestNDInterpolator
+from specutils import Spectrum1D
 
 import warnings
 
 import synphot as sp
 
 __all__ = ["Spectrum", "BinnedSpectrum", "SpectralGrid", "BinnedSpectralGrid"]
+
+
+_FWHM_TO_SIGMA = 1.0 / (2.0 * np.sqrt(2.0 * np.log(2.0)))
+_SAMPLES_PER_FWHM = 10
+_MIN_SAMPLES_PER_FWHM = 2
+# Limit the estimated peak working set for temporary coordinate/flux arrays.
+# Eight float64-sized arrays per temporary point is deliberately conservative.
+_MAX_TEMPORARY_WORKING_BYTES = 512 * 1024**2
+_ESTIMATED_BYTES_PER_TEMPORARY_POINT = 8 * np.dtype(float).itemsize
+
+
+def _validate_delta_lambda(delta_lambda):
+    """Return a positive scalar wavelength FWHM in Angstrom."""
+    if not isinstance(delta_lambda, u.Quantity):
+        raise TypeError(
+            "delta_lambda must be an astropy Quantity with wavelength units"
+        )
+    if not delta_lambda.unit.is_equivalent(u.AA):
+        raise u.UnitsError("delta_lambda must have wavelength units")
+
+    value = np.asarray(delta_lambda.to_value(u.AA))
+    if value.ndim != 0:
+        raise ValueError("delta_lambda must be a scalar")
+    value = float(value)
+    if not np.isfinite(value) or value <= 0:
+        raise ValueError("delta_lambda must be finite and positive")
+    return value
+
+
+def _validate_resolving_power(resolving_power):
+    """Return a positive scalar dimensionless resolving power."""
+    if isinstance(resolving_power, u.Quantity):
+        if not resolving_power.unit.is_equivalent(u.dimensionless_unscaled):
+            raise u.UnitsError("resolving_power must be dimensionless")
+        value = np.asarray(resolving_power.to_value(u.dimensionless_unscaled))
+    else:
+        if isinstance(resolving_power, (bool, np.bool_)):
+            raise TypeError("resolving_power must be a real scalar")
+        value = np.asarray(resolving_power)
+
+    if value.ndim != 0:
+        raise ValueError("resolving_power must be a scalar")
+    if np.iscomplexobj(value):
+        raise TypeError("resolving_power must be a real scalar")
+    try:
+        value = float(value)
+    except (TypeError, ValueError) as exc:
+        raise TypeError("resolving_power must be a real scalar") from exc
+    if not np.isfinite(value) or value <= 0:
+        raise ValueError("resolving_power must be finite and positive")
+    return value
+
+
+def _build_gaussian_convolution_plan(
+    wavelength,
+    *,
+    delta_lambda=None,
+    resolving_power=None,
+):
+    """Build reusable coordinate and kernel information for Gaussian smoothing."""
+    if (delta_lambda is None) == (resolving_power is None):
+        raise ValueError("Specify exactly one resolution mode")
+
+    wave = np.asarray(wavelength.to_value(u.AA), dtype=float)
+    if wave.ndim != 1 or wave.size < 2:
+        raise ValueError("The wavelength axis must contain at least two points")
+    if not np.all(np.isfinite(wave)):
+        raise ValueError("The wavelength axis must contain only finite values")
+
+    differences = np.diff(wave)
+    if np.all(differences > 0):
+        order = np.arange(wave.size)
+    elif np.all(differences < 0):
+        order = np.arange(wave.size - 1, -1, -1)
+    else:
+        raise ValueError("The wavelength axis must be strictly monotonic")
+
+    wave_ascending = wave[order]
+    if resolving_power is None:
+        coordinate = wave_ascending
+        coordinate_fwhm = delta_lambda
+        logarithmic = False
+    else:
+        if np.any(wave_ascending <= 0):
+            raise ValueError(
+                "Wavelengths must be positive for resolving-power convolution"
+            )
+        coordinate = np.log(wave_ascending)
+        coordinate_fwhm = 2.0 * np.arcsinh(1.0 / (2.0 * resolving_power))
+        logarithmic = True
+
+    coordinate_differences = np.diff(coordinate)
+    maximum_spacing = np.max(coordinate_differences)
+    required_fwhm = _MIN_SAMPLES_PER_FWHM * maximum_spacing
+    if coordinate_fwhm < required_fwhm:
+        resolution_name = (
+            "resolving power" if logarithmic else "wavelength resolution"
+        )
+        raise ValueError(
+            f"Requested {resolution_name} is under-sampled by the input grid: "
+            f"the target FWHM in the convolution coordinate is "
+            f"{coordinate_fwhm:.6g}, but at least {required_fwhm:.6g} is "
+            f"required for {_MIN_SAMPLES_PER_FWHM} samples per FWHM."
+        )
+
+    span = coordinate[-1] - coordinate[0]
+    target_spacing = min(
+        coordinate_fwhm / _SAMPLES_PER_FWHM,
+        np.min(coordinate_differences),
+    )
+    interval_count_float = span / target_spacing
+    maximum_temporary_points = (
+        _MAX_TEMPORARY_WORKING_BYTES
+        // _ESTIMATED_BYTES_PER_TEMPORARY_POINT
+    )
+    if (
+        not np.isfinite(interval_count_float)
+        or interval_count_float + 1 > maximum_temporary_points
+    ):
+        estimated_mib = (
+            (interval_count_float + 1)
+            * _ESTIMATED_BYTES_PER_TEMPORARY_POINT
+            / 1024**2
+        )
+        raise ValueError(
+            "Temporary convolution grid is impractical: the estimated "
+            f"working set is {estimated_mib:.1f} MiB, exceeding the "
+            f"{_MAX_TEMPORARY_WORKING_BYTES / 1024**2:.0f} MiB safety limit."
+        )
+
+    interval_count = max(1, int(np.ceil(interval_count_float)))
+    uniform_coordinate = np.linspace(
+        coordinate[0], coordinate[-1], interval_count + 1
+    )
+    uniform_spacing = uniform_coordinate[1] - uniform_coordinate[0]
+    sigma_pixels = coordinate_fwhm * _FWHM_TO_SIGMA / uniform_spacing
+    kernel_points = int(np.ceil(8.0 * sigma_pixels)) + 1
+    estimated_bytes = (
+        uniform_coordinate.size * _ESTIMATED_BYTES_PER_TEMPORARY_POINT
+        + kernel_points * np.dtype(float).itemsize
+    )
+    if estimated_bytes > _MAX_TEMPORARY_WORKING_BYTES:
+        raise ValueError(
+            "Temporary convolution grid is impractical: the estimated "
+            f"working set is {estimated_bytes / 1024**2:.1f} MiB, exceeding "
+            f"the {_MAX_TEMPORARY_WORKING_BYTES / 1024**2:.0f} MiB safety limit."
+        )
+
+    return {
+        "coordinate": coordinate,
+        "logarithmic": logarithmic,
+        "order": order,
+        "uniform_coordinate": uniform_coordinate,
+        "sigma_pixels": sigma_pixels,
+        "wave_ascending": wave_ascending,
+    }
+
+
+def _apply_gaussian_convolution_plan(flux, plan):
+    """Apply a prepared Gaussian convolution plan to one flux vector."""
+    from astropy.convolution import Gaussian1DKernel, convolve
+
+    values = np.asarray(flux, dtype=float)
+    if values.ndim != 1 or values.size != plan["order"].size:
+        raise ValueError(
+            "Flux must be one-dimensional and match the wavelength axis"
+        )
+
+    values_ascending = values[plan["order"]]
+    if plan["logarithmic"]:
+        # d(lambda) = lambda d(ln(lambda)), so lambda * F_lambda is the
+        # appropriate density to convolve when preserving wavelength-integrated
+        # flux in the continuous, unbounded-domain limit.
+        density = plan["wave_ascending"] * values_ascending
+    else:
+        density = values_ascending
+
+    uniform_density = np.interp(
+        plan["uniform_coordinate"],
+        plan["coordinate"],
+        density,
+    )
+
+    kernel = Gaussian1DKernel(plan["sigma_pixels"])
+    convolved_density = convolve(uniform_density, kernel, boundary="extend")
+    output_density = np.interp(
+        plan["coordinate"],
+        plan["uniform_coordinate"],
+        convolved_density,
+        left=convolved_density[0],
+        right=convolved_density[-1],
+    )
+
+    if plan["logarithmic"]:
+        output_ascending = output_density / plan["wave_ascending"]
+    else:
+        output_ascending = output_density
+
+    output = np.empty_like(output_ascending)
+    output[plan["order"]] = output_ascending
+    return output
+
+
+def _validate_spectrum_convolution_state(spectrum):
+    """Reject ancillary state that cannot be propagated scientifically."""
+    if spectrum.mask is not None:
+        raise NotImplementedError(
+            "Spectral convolution does not yet support masked spectra"
+        )
+    if spectrum.uncertainty is not None:
+        raise NotImplementedError(
+            "Spectral convolution does not yet propagate uncertainties"
+        )
 
 
 class Spectrum(Spectrum1D):
@@ -622,33 +837,98 @@ class Spectrum(Spectrum1D):
 
         return spec_new
 
-    @u.quantity_input(spectral_resolution=u.AA)
-    def set_spectral_resolution(self, spectral_resolution):
+    def set_spectral_resolution(self, delta_lambda):
         """
-        Set the spectral resolution by convolution with a Gaussian.
+        Return a spectrum with constant Gaussian wavelength resolution.
 
         Parameters
         ----------
-        spectral_resolution : `~astropy.units.Quantity`
-            The spectral resolution.
+        delta_lambda : `~astropy.units.Quantity`
+            Positive scalar Gaussian FWHM with wavelength units.
 
         Returns
         -------
         spec_new : `~speclib.Spectrum`
-            A spectrum with the desired spectral resolution.
+            A new spectrum on the original spectral axis. The input spectrum is
+            not modified.
+
+        Notes
+        -----
+        The intrinsic input line width is assumed to be negligible relative to
+        ``delta_lambda``. No deconvolution or correction for finite input
+        resolution is performed. The input must provide at least two samples
+        per requested FWHM across every wavelength interval. Internally, the
+        temporary grid has at least ten samples per FWHM and is no coarser than
+        the finest input interval.
+
+        Features within four Gaussian standard deviations of a boundary can
+        lose flux or have a truncated profile because no spectrum is invented
+        outside the observed range. Masked spectra and spectra with uncertainty
+        arrays are rejected because propagating that state is outside the scope
+        of this operation.
         """
-        from astropy.convolution import convolve, Gaussian1DKernel
+        _validate_spectrum_convolution_state(self)
+        delta_lambda_value = _validate_delta_lambda(delta_lambda)
+        plan = _build_gaussian_convolution_plan(
+            self.wavelength,
+            delta_lambda=delta_lambda_value,
+        )
+        convolved_flux = _apply_gaussian_convolution_plan(self.flux.value, plan)
+        return Spectrum(
+            spectral_axis=self.spectral_axis.copy(),
+            flux=convolved_flux * self.flux.unit,
+            meta=copy.deepcopy(self.meta),
+        )
 
-        # # First, check if grid spacing is regular
-        # delta_lambdas = np.unique(self.wavelength.diff())
-        delta_lambda = np.unique(self.wavelength.diff()).min()
+    def set_spectral_resolving_power(self, resolving_power):
+        """Return a spectrum broadened to constant resolving power.
 
-        kernel_size = (spectral_resolution / delta_lambda).value  # resolution elements
-        kernel = Gaussian1DKernel(kernel_size)
-        convolved_flux = convolve(self.flux, kernel, boundary="extend")
-        spec_new = Spectrum(spectral_axis=self.wavelength, flux=convolved_flux)
+        Parameters
+        ----------
+        resolving_power : float or `~astropy.units.Quantity`
+            Positive scalar resolving power, :math:`R = \\lambda/\\Delta\\lambda`.
+            A quantity must be dimensionless.
 
-        return spec_new
+        Returns
+        -------
+        spec_new : `~speclib.Spectrum`
+            A new spectrum on the original spectral axis. The input spectrum is
+            not modified.
+
+        Notes
+        -----
+        Convolution is evaluated on a uniform log-wavelength grid. To use the
+        physical wavelength-flux measure, ``lambda * F_lambda`` is convolved
+        and the result is divided by wavelength afterward. This preserves
+        wavelength-integrated flux in the continuous, unbounded-domain limit;
+        finite boundaries and numerical remapping limit exact conservation.
+
+        The stationary Gaussian therefore applies to flux per logarithmic
+        wavelength interval. Expressed as ``F_lambda``, an isolated feature has
+        a log-normal-like profile that is not exactly symmetric in linear
+        wavelength. This distinction is small at ordinary astronomical
+        resolving powers. The input must provide at least two samples per
+        requested log-wavelength FWHM across every interval.
+
+        The intrinsic input line width is assumed to be negligible relative to
+        the requested broadening. Wavelength-dependent resolving power is not
+        supported. Features within four Gaussian standard deviations of a
+        boundary do not have the same flux or resolution guarantees as interior
+        features. Masked spectra and spectra with uncertainty arrays are
+        rejected.
+        """
+        _validate_spectrum_convolution_state(self)
+        resolving_power_value = _validate_resolving_power(resolving_power)
+        plan = _build_gaussian_convolution_plan(
+            self.wavelength,
+            resolving_power=resolving_power_value,
+        )
+        convolved_flux = _apply_gaussian_convolution_plan(self.flux.value, plan)
+        return Spectrum(
+            spectral_axis=self.spectral_axis.copy(),
+            flux=convolved_flux * self.flux.unit,
+            meta=copy.deepcopy(self.meta),
+        )
 
     @u.quantity_input(center=u.AA, width=u.AA)
     def bin(self, center, width):
@@ -840,6 +1120,7 @@ class SpectralGrid(object):
         wavelength=None,
         spectral_resolution=None,
         model_grid="phoenix",
+        spectral_resolving_power=None,
         **kwargs,
     ):
         """
@@ -858,11 +1139,27 @@ class SpectralGrid(object):
             Wavelengths of the interpolated spectrum.
 
         spectral_resolution : `~astropy.units.Quantity`
-            The spectral resolution.
+            Constant Gaussian FWHM in wavelength to apply to every spectrum.
+
+        spectral_resolving_power : float or `~astropy.units.Quantity`, optional
+            Constant resolving power to apply to every spectrum.
 
         model_grid : str, optional
             Name of the model grid.
         """
+        if (
+            spectral_resolution is not None
+            and spectral_resolving_power is not None
+        ):
+            raise ValueError(
+                "Specify only one of spectral_resolution or "
+                "spectral_resolving_power."
+            )
+        if spectral_resolution is not None:
+            _validate_delta_lambda(spectral_resolution)
+        if spectral_resolving_power is not None:
+            _validate_resolving_power(spectral_resolving_power)
+
         # First check that the model_grid is valid.
         self.model_grid = model_grid.lower()
         if self.model_grid not in utils.VALID_MODELS:
@@ -921,11 +1218,6 @@ class SpectralGrid(object):
                         # Skip combinations that do not exist in sparse grids
                         continue
 
-                    # Set spectral resolution if specified
-                    if spectral_resolution is not None:
-                        spec = spec.regularize()
-                        spec = spec.set_spectral_resolution(spectral_resolution)
-
                     # Resample the spectrum to the desired wavelength array
                     if wavelength is not None:
                         spec = spec.resample(wavelength)
@@ -951,6 +1243,125 @@ class SpectralGrid(object):
             self.points = np.empty((0, 3))
             self.data = np.empty((0,))
             self.interpolator = None
+
+        if spectral_resolution is not None:
+            resolved_grid = self.set_spectral_resolution(spectral_resolution)
+            self.fluxes = resolved_grid.fluxes
+            self.data = resolved_grid.data
+            self.interpolator = resolved_grid.interpolator
+        elif spectral_resolving_power is not None:
+            resolved_grid = self.set_spectral_resolving_power(
+                spectral_resolving_power
+            )
+            self.fluxes = resolved_grid.fluxes
+            self.data = resolved_grid.data
+            self.interpolator = resolved_grid.interpolator
+
+    def _with_gaussian_convolution(self, plan):
+        """Return an in-memory copy with a convolution plan applied."""
+        if self.wavelength is None or not self.points.size:
+            raise ValueError("SpectralGrid contains no spectra")
+
+        new_fluxes = {
+            teff: {
+                logg: dict(fluxes_by_feh)
+                for logg, fluxes_by_feh in fluxes_by_logg.items()
+            }
+            for teff, fluxes_by_logg in self.fluxes.items()
+        }
+        new_rows = []
+        for teff, logg, feh in self.points:
+            flux = self.fluxes[teff][logg][feh].to(self.unit)
+            convolved_values = _apply_gaussian_convolution_plan(flux.value, plan)
+            convolved_flux = convolved_values * self.unit
+            new_fluxes[teff][logg][feh] = convolved_flux
+            new_rows.append(convolved_values)
+
+        new_grid = copy.copy(self)
+        for attribute in (
+            "wavelength",
+            "points",
+            "teffs",
+            "loggs",
+            "fehs",
+            "grid_teffs",
+            "grid_loggs",
+            "grid_fehs",
+        ):
+            if hasattr(self, attribute):
+                value = getattr(self, attribute)
+                setattr(
+                    new_grid,
+                    attribute,
+                    value.copy() if hasattr(value, "copy") else copy.copy(value),
+                )
+        if hasattr(self, "grid_points"):
+            new_grid.grid_points = copy.deepcopy(self.grid_points)
+        new_grid.fluxes = new_fluxes
+        new_grid.data = np.vstack(new_rows)
+        new_grid.interpolator = NearestNDInterpolator(
+            new_grid.points, new_grid.data
+        )
+        return new_grid
+
+    def set_spectral_resolution(self, delta_lambda):
+        """Return a new grid with constant Gaussian wavelength resolution.
+
+        Parameters
+        ----------
+        delta_lambda : `~astropy.units.Quantity`
+            Positive scalar Gaussian FWHM with wavelength units.
+
+        Returns
+        -------
+        grid_new : `~speclib.SpectralGrid`
+            A new grid containing the convolved spectra.
+
+        Notes
+        -----
+        Every stored spectrum is convolved to the requested wavelength FWHM.
+        The original grid and its wavelength sampling are unchanged.
+        Intrinsic input line widths are assumed to be negligible. Sampling and
+        boundary behavior match :meth:`Spectrum.set_spectral_resolution`.
+        """
+        if self.wavelength is None or not self.points.size:
+            raise ValueError("SpectralGrid contains no spectra")
+        delta_lambda_value = _validate_delta_lambda(delta_lambda)
+        plan = _build_gaussian_convolution_plan(
+            self.wavelength,
+            delta_lambda=delta_lambda_value,
+        )
+        return self._with_gaussian_convolution(plan)
+
+    def set_spectral_resolving_power(self, resolving_power):
+        """Return a new grid with constant resolving power.
+
+        Parameters
+        ----------
+        resolving_power : float or `~astropy.units.Quantity`
+            Positive scalar dimensionless resolving power.
+
+        Returns
+        -------
+        grid_new : `~speclib.SpectralGrid`
+            A new grid containing the convolved spectra.
+
+        Notes
+        -----
+        Every stored spectrum is convolved on the same internal log-wavelength
+        grid. The original grid and its wavelength sampling are unchanged.
+        Intrinsic input line widths are assumed to be negligible. Flux,
+        sampling, and boundary conventions match
+        :meth:`Spectrum.set_spectral_resolving_power`.
+        """
+        if self.wavelength is None or not self.points.size:
+            raise ValueError("SpectralGrid contains no spectra")
+        resolving_power_value = _validate_resolving_power(resolving_power)
+        plan = _build_gaussian_convolution_plan(
+            self.wavelength,
+            resolving_power=resolving_power_value,
+        )
+        return self._with_gaussian_convolution(plan)
 
     def get_flux(self, teff, logg, feh, interpolate=True):
         """

--- a/tests/test_resolution.py
+++ b/tests/test_resolution.py
@@ -1,0 +1,450 @@
+import astropy.units as u
+import numpy as np
+import pytest
+from astropy.nddata import StdDevUncertainty
+from scipy.interpolate import NearestNDInterpolator
+
+from speclib import Spectrum
+from speclib import utils
+from speclib.core import SpectralGrid
+
+
+FLUX_UNIT = u.erg / u.s / u.cm**2 / u.AA
+LINE_CENTERS = np.array([4500.0, 5500.0, 6500.0])
+
+
+def _synthetic_spectrum(scale=1.0):
+    wave = np.concatenate(
+        (
+            np.arange(4300.0, 5200.0, 0.04),
+            np.arange(5200.0, 6000.0, 0.08),
+            np.arange(6000.0, 6700.0, 0.12),
+        )
+    )
+    intrinsic_sigma = 0.24 / (2.0 * np.sqrt(2.0 * np.log(2.0)))
+    flux = np.ones(wave.size)
+    for center in LINE_CENTERS:
+        flux += scale * np.exp(-0.5 * ((wave - center) / intrinsic_sigma) ** 2)
+    return Spectrum(spectral_axis=wave * u.AA, flux=flux * FLUX_UNIT)
+
+
+def _measure_fwhm(wavelength, flux, center):
+    mask = np.abs(wavelength - center) < 15.0
+    wave_window = wavelength[mask]
+    flux_window = flux[mask]
+    baseline = np.median(np.concatenate((flux_window[:30], flux_window[-30:])))
+    profile = flux_window - baseline
+    peak_index = np.argmax(profile)
+    half_maximum = profile[peak_index] / 2.0
+
+    left = np.interp(
+        half_maximum,
+        profile[: peak_index + 1],
+        wave_window[: peak_index + 1],
+    )
+    right = np.interp(
+        half_maximum,
+        profile[peak_index:][::-1],
+        wave_window[peak_index:][::-1],
+    )
+    return right - left
+
+
+def _line_area_and_centroid(wavelength, flux):
+    area = np.trapezoid(flux, wavelength)
+    centroid = np.trapezoid(wavelength * flux, wavelength) / area
+    return area, centroid
+
+
+def _make_grid():
+    grid = SpectralGrid.__new__(SpectralGrid)
+    first = _synthetic_spectrum(scale=1.0)
+    second = _synthetic_spectrum(scale=1.5)
+    grid.model_grid = "phoenix"
+    grid.wavelength = first.wavelength.copy()
+    grid.unit = FLUX_UNIT
+    grid.points = np.array([[3000.0, 4.0, 0.0], [3100.0, 4.0, 0.0]])
+    grid.teffs = np.array([3000.0, 3100.0])
+    grid.loggs = np.array([4.0])
+    grid.fehs = np.array([0.0])
+    grid.teff_bds = (3000.0, 3100.0)
+    grid.logg_bds = (4.0, 4.0)
+    grid.feh_bds = (0.0, 0.0)
+    grid.fluxes = {
+        3000.0: {4.0: {0.0: first.flux.copy()}},
+        3100.0: {4.0: {0.0: second.flux.copy()}},
+    }
+    grid.data = np.vstack((first.flux.value, second.flux.value))
+    grid.interpolator = NearestNDInterpolator(grid.points, grid.data)
+    return grid
+
+
+def _assert_grid_unchanged(grid, original_data, original_fluxes):
+    np.testing.assert_array_equal(grid.data, original_data)
+    for point, expected in zip(grid.points, original_fluxes):
+        teff, logg, feh = point
+        np.testing.assert_array_equal(
+            grid.fluxes[teff][logg][feh].value,
+            expected,
+        )
+
+
+def test_spectrum_set_spectral_resolution_has_constant_delta_lambda():
+    spectrum = _synthetic_spectrum()
+    original_flux = spectrum.flux.copy()
+
+    result = spectrum.set_spectral_resolution(4.0 * u.AA)
+
+    widths = np.array(
+        [
+            _measure_fwhm(result.wavelength.value, result.flux.value, center)
+            for center in LINE_CENTERS
+        ]
+    )
+    np.testing.assert_allclose(widths, 4.0, rtol=0.03)
+    np.testing.assert_array_equal(result.spectral_axis, spectrum.spectral_axis)
+    np.testing.assert_array_equal(spectrum.flux, original_flux)
+    assert result is not spectrum
+
+
+def test_spectrum_set_spectral_resolving_power_has_constant_r():
+    spectrum = _synthetic_spectrum()
+    original_flux = spectrum.flux.copy()
+
+    result = spectrum.set_spectral_resolving_power(1500.0)
+
+    widths = np.array(
+        [
+            _measure_fwhm(result.wavelength.value, result.flux.value, center)
+            for center in LINE_CENTERS
+        ]
+    )
+    np.testing.assert_allclose(LINE_CENTERS / widths, 1500.0, rtol=0.03)
+    np.testing.assert_array_equal(result.spectral_axis, spectrum.spectral_axis)
+    np.testing.assert_array_equal(spectrum.flux, original_flux)
+    assert result is not spectrum
+
+
+def test_phase_shifted_lines_preserve_centroids():
+    wavelength = np.arange(4900.0, 5100.001, 0.01)
+    input_sigma = 0.02
+    centroid_shifts = []
+    for center in (4999.83, 4999.91, 5000.07, 5000.16):
+        flux = np.exp(-0.5 * ((wavelength - center) / input_sigma) ** 2)
+        spectrum = Spectrum(
+            spectral_axis=wavelength * u.AA,
+            flux=flux * FLUX_UNIT,
+        )
+
+        result = spectrum.set_spectral_resolution(4.0 * u.AA)
+
+        _, input_centroid = _line_area_and_centroid(wavelength, flux)
+        _, output_centroid = _line_area_and_centroid(
+            wavelength,
+            result.flux.value,
+        )
+        centroid_shifts.append(output_centroid - input_centroid)
+
+    np.testing.assert_allclose(centroid_shifts, 0.0, atol=1e-6)
+
+
+def test_spectrum_resolving_power_preserves_isolated_line_flux():
+    wavelength = np.arange(4000.0, 8000.01, 0.05)
+    center = 6000.13
+    flux = np.exp(-0.5 * ((wavelength - center) / 0.08) ** 2)
+    spectrum = Spectrum(
+        spectral_axis=wavelength * u.AA,
+        flux=flux * FLUX_UNIT,
+    )
+
+    result = spectrum.set_spectral_resolving_power(1500.0)
+
+    input_integral, _ = _line_area_and_centroid(wavelength, flux)
+    output_integral, _ = _line_area_and_centroid(
+        wavelength,
+        result.flux.value,
+    )
+    assert output_integral == pytest.approx(input_integral, rel=5e-4)
+
+
+def test_edge_line_has_no_interior_flux_guarantee():
+    wavelength = np.arange(5000.0, 5100.01, 0.02)
+    flux = np.exp(-0.5 * ((wavelength - 5000.5) / 0.05) ** 2)
+    spectrum = Spectrum(
+        spectral_axis=wavelength * u.AA,
+        flux=flux * FLUX_UNIT,
+    )
+
+    result = spectrum.set_spectral_resolution(4.0 * u.AA)
+
+    input_integral, _ = _line_area_and_centroid(wavelength, flux)
+    output_integral, _ = _line_area_and_centroid(
+        wavelength,
+        result.flux.value,
+    )
+    assert output_integral < 0.8 * input_integral
+
+
+def test_spectrum_resolution_methods_support_descending_wavelengths():
+    spectrum = _synthetic_spectrum()
+    descending = Spectrum(
+        spectral_axis=spectrum.spectral_axis[::-1].copy(),
+        flux=spectrum.flux[::-1].copy(),
+    )
+
+    ascending_result = spectrum.set_spectral_resolving_power(1500.0)
+    descending_result = descending.set_spectral_resolving_power(1500.0)
+
+    np.testing.assert_array_equal(
+        descending_result.spectral_axis,
+        descending.spectral_axis,
+    )
+    np.testing.assert_allclose(
+        descending_result.flux[::-1],
+        ascending_result.flux,
+        rtol=1e-12,
+    )
+
+
+def test_spectrum_resolution_methods_return_independent_objects():
+    spectrum = _synthetic_spectrum()
+    spectrum.meta["nested"] = {"value": 1}
+
+    result = spectrum.set_spectral_resolution(4.0 * u.AA)
+    result.spectral_axis[0] = 4200.0 * u.AA
+    result.meta["nested"]["value"] = 2
+
+    assert spectrum.spectral_axis[0] != result.spectral_axis[0]
+    assert spectrum.meta["nested"]["value"] == 1
+
+
+def test_spectrum_resolution_methods_reject_masks_and_uncertainties():
+    spectrum = _synthetic_spectrum()
+    masked = Spectrum(
+        spectral_axis=spectrum.spectral_axis,
+        flux=spectrum.flux,
+        mask=np.zeros(spectrum.flux.size, dtype=bool),
+    )
+    uncertain = Spectrum(
+        spectral_axis=spectrum.spectral_axis,
+        flux=spectrum.flux,
+        uncertainty=StdDevUncertainty(np.ones(spectrum.flux.size)),
+    )
+
+    with pytest.raises(NotImplementedError, match="masked"):
+        masked.set_spectral_resolution(4.0 * u.AA)
+    with pytest.raises(NotImplementedError, match="uncertainties"):
+        uncertain.set_spectral_resolving_power(1500.0)
+
+
+def test_spectrum_rejects_under_sampled_wavelength_resolution():
+    wavelength = np.arange(4900.0, 5101.0, 1.0)
+    spectrum = Spectrum(
+        spectral_axis=wavelength * u.AA,
+        flux=np.ones(wavelength.size) * FLUX_UNIT,
+    )
+
+    with pytest.raises(ValueError, match="under-sampled"):
+        spectrum.set_spectral_resolution(1.99 * u.AA)
+
+    result = spectrum.set_spectral_resolution(2.01 * u.AA)
+    np.testing.assert_array_equal(result.spectral_axis, spectrum.spectral_axis)
+
+
+def test_spectrum_rejects_under_sampled_resolving_power():
+    wavelength = np.arange(5000.0, 5101.0, 1.0)
+    spectrum = Spectrum(
+        spectral_axis=wavelength * u.AA,
+        flux=np.ones(wavelength.size) * FLUX_UNIT,
+    )
+
+    with pytest.raises(ValueError, match="under-sampled"):
+        spectrum.set_spectral_resolving_power(3000.0)
+
+
+def test_spectrum_rejects_impractical_temporary_grid():
+    wavelength = 5000.0 + np.concatenate(
+        ([0.0, 1e-8], np.arange(1.0, 101.0))
+    )
+    spectrum = Spectrum(
+        spectral_axis=wavelength * u.AA,
+        flux=np.ones(wavelength.size) * FLUX_UNIT,
+    )
+
+    with pytest.raises(ValueError, match="safety limit"):
+        spectrum.set_spectral_resolution(3.0 * u.AA)
+
+
+@pytest.mark.parametrize("value", [0.0 * u.AA, -1.0 * u.AA, np.nan * u.AA])
+def test_spectrum_set_spectral_resolution_rejects_nonpositive_or_nonfinite(value):
+    with pytest.raises(ValueError):
+        _synthetic_spectrum().set_spectral_resolution(value)
+
+
+@pytest.mark.parametrize("value", [0.0, -1.0, np.nan, np.inf])
+def test_spectrum_set_spectral_resolving_power_rejects_invalid_values(value):
+    with pytest.raises(ValueError):
+        _synthetic_spectrum().set_spectral_resolving_power(value)
+
+
+def test_spectrum_resolution_methods_reject_invalid_units_and_shapes():
+    spectrum = _synthetic_spectrum()
+    with pytest.raises(u.UnitsError):
+        spectrum.set_spectral_resolution(1.0 * u.s)
+    with pytest.raises(ValueError):
+        spectrum.set_spectral_resolution(np.array([1.0, 2.0]) * u.AA)
+    with pytest.raises(u.UnitsError):
+        spectrum.set_spectral_resolving_power(1500.0 * u.AA)
+    with pytest.raises(ValueError):
+        spectrum.set_spectral_resolving_power(np.array([1000.0, 1500.0]))
+
+
+@pytest.mark.parametrize(
+    ("method_name", "value"),
+    [
+        ("set_spectral_resolution", 4.0 * u.AA),
+        ("set_spectral_resolving_power", 1500.0),
+    ],
+)
+def test_spectral_grid_resolution_methods_update_all_spectra_without_mutation(
+    method_name,
+    value,
+):
+    grid = _make_grid()
+    original_data = grid.data.copy()
+    original_fluxes = [
+        grid.fluxes[teff][logg][feh].value.copy()
+        for teff, logg, feh in grid.points
+    ]
+
+    result = getattr(grid, method_name)(value)
+
+    assert result is not grid
+    np.testing.assert_array_equal(result.wavelength, grid.wavelength)
+    assert not np.array_equal(result.data, grid.data)
+    _assert_grid_unchanged(grid, original_data, original_fluxes)
+
+    for row, (teff, logg, feh) in zip(result.data, result.points):
+        np.testing.assert_array_equal(
+            row,
+            result.fluxes[teff][logg][feh].value,
+        )
+        assert not np.array_equal(row, grid.fluxes[teff][logg][feh].value)
+
+    np.testing.assert_allclose(
+        result.interpolator(result.points[0]).reshape(-1),
+        result.data[0],
+    )
+
+    source_flux = grid.fluxes[3000.0][4.0][0.0]
+    expected_spectrum = getattr(
+        Spectrum(spectral_axis=grid.wavelength, flux=source_flux),
+        method_name,
+    )(value)
+    np.testing.assert_allclose(result.data[0], expected_spectrum.flux.value)
+
+    widths = np.array(
+        [
+            _measure_fwhm(result.wavelength.value, result.data[0], center)
+            for center in LINE_CENTERS
+        ]
+    )
+    if method_name == "set_spectral_resolution":
+        np.testing.assert_allclose(widths, value.to_value(u.AA), rtol=0.03)
+    else:
+        np.testing.assert_allclose(LINE_CENTERS / widths, value, rtol=0.03)
+
+
+def test_spectral_grid_result_has_independent_mutable_state():
+    grid = _make_grid()
+    original_wavelength = grid.wavelength.copy()
+    original_points = grid.points.copy()
+    original_teffs = grid.teffs.copy()
+    original_flux = grid.fluxes[3000.0][4.0][0.0].copy()
+
+    result = grid.set_spectral_resolution(4.0 * u.AA)
+    result.wavelength[0] = 4200.0 * u.AA
+    result.points[0, 0] = 9999.0
+    result.teffs[0] = 9999.0
+    result.fluxes[3000.0][4.0][0.0][0] = 99.0 * FLUX_UNIT
+
+    np.testing.assert_array_equal(grid.wavelength, original_wavelength)
+    np.testing.assert_array_equal(grid.points, original_points)
+    np.testing.assert_array_equal(grid.teffs, original_teffs)
+    np.testing.assert_array_equal(grid.fluxes[3000.0][4.0][0.0], original_flux)
+
+
+@pytest.fixture
+def synthetic_grid_loader(monkeypatch):
+    monkeypatch.setitem(
+        utils.GRID_POINTS,
+        "phoenix",
+        {
+            "grid_teffs": np.array([3000.0, 3100.0]),
+            "grid_loggs": np.array([4.0]),
+            "grid_fehs": np.array([0.0]),
+        },
+    )
+
+    def fake_from_grid(cls, teff, logg, feh=0.0, **kwargs):
+        return _synthetic_spectrum(scale=1.0 + (teff - 3000.0) / 1000.0)
+
+    monkeypatch.setattr(Spectrum, "from_grid", classmethod(fake_from_grid))
+
+
+def _construct_synthetic_grid(**kwargs):
+    return SpectralGrid(
+        teff_bds=(3000.0, 3100.0),
+        logg_bds=(4.0, 4.0),
+        feh_bds=(0.0, 0.0),
+        model_grid="phoenix",
+        **kwargs,
+    )
+
+
+@pytest.mark.parametrize(
+    ("constructor_keyword", "method_name", "value"),
+    [
+        ("spectral_resolution", "set_spectral_resolution", 4.0 * u.AA),
+        (
+            "spectral_resolving_power",
+            "set_spectral_resolving_power",
+            1500.0,
+        ),
+    ],
+)
+def test_spectral_grid_constructor_options_match_methods(
+    synthetic_grid_loader,
+    constructor_keyword,
+    method_name,
+    value,
+):
+    base_grid = _construct_synthetic_grid()
+    expected = getattr(base_grid, method_name)(value)
+    constructed = _construct_synthetic_grid(**{constructor_keyword: value})
+
+    np.testing.assert_array_equal(constructed.wavelength, base_grid.wavelength)
+    np.testing.assert_allclose(constructed.data, expected.data, rtol=1e-12)
+
+
+def test_spectral_grid_constructor_rejects_both_resolution_options(
+    synthetic_grid_loader,
+):
+    with pytest.raises(ValueError, match="Specify only one"):
+        _construct_synthetic_grid(
+            spectral_resolution=4.0 * u.AA,
+            spectral_resolving_power=1500.0,
+        )
+
+
+def test_spectral_grid_constructor_does_not_regularize(
+    synthetic_grid_loader,
+    monkeypatch,
+):
+    def fail_if_called(self, delta_lambda=None):
+        raise AssertionError("regularize() must not be called implicitly")
+
+    monkeypatch.setattr(Spectrum, "regularize", fail_if_called)
+    grid = _construct_synthetic_grid(spectral_resolution=4.0 * u.AA)
+
+    assert grid.wavelength is not None


### PR DESCRIPTION
## Summary

This change distinguishes two Gaussian broadening operations:

- **Spectral resolution** uses a constant wavelength FWHM, Δλ, so resolving power varies as `R(λ) = λ / Δλ`.
- **Spectral resolving power** uses constant `R`, so the wavelength FWHM varies as `Δλ(λ) = λ / R`.

Both `Spectrum` and `SpectralGrid` now provide:

- `set_spectral_resolution(delta_lambda)`
- `set_spectral_resolving_power(resolving_power)`

These methods return new objects, leave the originals unchanged, and preserve the input wavelength sampling and ordering. Nonuniform wavelength grids are handled through temporary internal grids and remapped onto the original spectral axis.

`SpectralGrid` also supports the corresponding `spectral_resolution` and `spectral_resolving_power` constructor options. They share the same numerical machinery as the post-construction methods, and specifying both raises `ValueError`. Model spectra are not reloaded when producing a modified grid.

The previous implicit `regularize()` call has been removed. Sampling changes now occur only when users explicitly call `regularize()`.

## Numerical approach

Constant-Δλ broadening is evaluated on a temporary uniform linear-wavelength grid. Constant-R broadening is evaluated on a uniform `ln(λ)` grid, using a Gaussian log-wavelength FWHM corresponding to `Δλ / λ = 1 / R`. Both paths convert Gaussian FWHM to sigma using:

`σ = FWHM / (2 sqrt(2 ln 2))`

For constant R, the implementation uses the Jacobian relationship:

`F_λ dλ = λ F_λ d ln(λ)`

It therefore convolves `λ F_λ` as the flux density in log wavelength and divides by λ afterward. This preserves wavelength-integrated flux in the continuous, unbounded-domain limit; finite boundaries and interpolation/remapping prevent an unconditional exact-conservation guarantee over the returned interval.

Inputs must provide at least two samples per requested FWHM in the relevant convolution coordinate. Temporary grids use at least ten samples per FWHM and are no coarser than the finest input interval. A conservative 512 MiB working-memory guard rejects impractical temporary grids before allocation.

## Documented limitations

- The intrinsic input line width is assumed negligible relative to the requested target broadening; no deconvolution or input-resolution correction is performed.
- Features within four Gaussian sigma of an edge may have truncated profiles or lose flux.
- Spectra with masks or uncertainties are rejected because propagation rules are not yet defined.
- Wavelength-dependent resolving power, `R(λ)`, is not supported.

## Tests

Quantitative regression tests use synthetic narrow features at multiple wavelengths to verify:

- constant measured Δλ for `set_spectral_resolution()`;
- constant measured `λ / Δλ` for `set_spectral_resolving_power()`;
- integrated-flux behavior for isolated constant-R features;
- nonuniform and descending wavelength grids;
- preservation of the exact input spectral axis;
- immutable `Spectrum` and `SpectralGrid` behavior;
- consistent grid constructor and post-construction results;
- sampling, units, input validation, edge behavior, and the memory guard.

Verification:

- `poetry run pytest` — **49 passed**
- `poetry run tox`
  - Python 3.11 — **49 passed**
  - Python 3.12 — **49 passed**
  - Python 3.13 — **49 passed**

Closes #36