### PR TITLE
Support wavelength-dependent Gaussian resolving power R(λ)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- Added wavelength-dependent Gaussian resolving-power support for `Spectrum`
+  and `SpectralGrid` with `set_variable_resolving_power()`.
+
+
 ## [0.1.0b12] - 2026-08-21
 
 ### Added

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -62,6 +62,40 @@ has a log-normal-like profile rather than a profile that is exactly symmetric
 in linear wavelength. This convention is intended primarily for ordinary
 astronomical resolving powers, where the distinction is small.
 
+Variable resolving power
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+:meth:`speclib.Spectrum.set_variable_resolving_power` accepts sampled
+wavelength and resolving-power arrays and linearly interpolates
+:math:`R(\lambda)` between them:
+
+.. code-block:: python
+
+   curve_wavelength = [0.6, 1.0, 2.0, 5.3] * u.um
+   curve_resolving_power = [30, 100, 200, 300]
+   broadened = spectrum.set_variable_resolving_power(
+       curve_wavelength,
+       curve_resolving_power,
+   )
+
+The sampled curve must cover the full wavelength range of the input spectrum;
+the method does not extrapolate. :math:`R(\lambda)` is intended to vary
+smoothly relative to a local resolution element. A resolving-power curve by
+itself is not sufficient to describe an instrument whose line-spread function
+changes substantially across one local FWHM; such cases require a calibrated
+wavelength-dependent LSF.
+
+Each input wavelength contributes a source-centered Gaussian with its local
+resolving power. This conserves wavelength-integrated flux and uses the same
+log-wavelength and flux conventions as constant resolving power. A constant
+sampled curve therefore reproduces
+:meth:`speclib.Spectrum.set_spectral_resolving_power` within numerical
+tolerance.
+
+The returned spectrum retains the exact input wavelength axis. If detector or
+extracted-spectrum sampling is also required, apply :meth:`~speclib.Spectrum.resample`
+as a separate operation.
+
 Sampling and temporary grids
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -72,39 +106,47 @@ this criterion is evaluated in log wavelength and is equivalent locally to
 requiring two samples across :math:`\lambda/R`. Under-sampled requests raise a
 ``ValueError``.
 
-The internal uniform grid has at least ten samples per Gaussian FWHM and is no
-coarser than the finest input interval. Before allocating it, speclib estimates
-a conservative working set of eight float64 arrays per temporary point and
-rejects operations exceeding 512 MiB. This prevents pathological sampling or
-resolution requests from causing accidental unbounded allocations.
+Constant-width operations use an internal uniform grid with at least ten
+samples per Gaussian FWHM and no coarser spacing than the finest input
+interval. Variable resolving power instead uses an adaptive grid whose local
+spacing follows the requested FWHM. Before allocating either representation,
+speclib estimates its work and memory requirements and rejects impractical
+operations. This avoids combining global sampling set by the narrowest kernel
+with support set by the broadest kernel.
 
 Edges and ancillary state
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The convolution extends the endpoint value beyond each boundary. No missing
-spectrum is reconstructed outside the observed range. Features within four
-Gaussian standard deviations of a boundary can therefore lose flux and have a
-truncated line-spread function; the interior flux and resolution guarantees do
-not apply there.
+Constant-width convolution extends the endpoint value beyond each boundary.
+Variable-width kernels are truncated and renormalized at the returned
+wavelength limits. No missing spectrum is reconstructed outside the observed
+range, and edge line-spread functions should not be interpreted as complete
+instrument profiles. Interior resolution and centroid guarantees do not apply
+near a boundary.
 
 Masks and uncertainties require scientifically explicit propagation rules.
 Because those rules are outside the scope of these methods, spectra containing
 either are rejected instead of silently dropping or copying unsupported state.
 
-Both operations assume that the intrinsic input line width is negligible
+All resolution operations assume that the intrinsic input line width is negligible
 relative to the requested broadening. They do not deconvolve a known input
-line-spread function, and wavelength-dependent resolving power is not supported.
+line-spread function. Variable resolving power assumes a Gaussian line-spread
+function; wavelength-dependent non-Gaussian profiles are not supported.
 
 Spectral grids
 ~~~~~~~~~~~~~~
 
-:class:`speclib.SpectralGrid` provides the same two methods. They return new
+:class:`speclib.SpectralGrid` provides the same three methods. They return new
 grid objects without reloading model spectra or modifying the originals:
 
 .. code-block:: python
 
    low_resolution_grid = grid.set_spectral_resolution(5 * u.AA)
    constant_r_grid = grid.set_spectral_resolving_power(2700)
+   variable_r_grid = grid.set_variable_resolving_power(
+       curve_wavelength,
+       curve_resolving_power,
+   )
 
 The equivalent constructor options are ``spectral_resolution`` and
 ``spectral_resolving_power``. Only one may be supplied at a time.

--- a/src/speclib/core.py
+++ b/src/speclib/core.py
@@ -18,11 +18,15 @@ __all__ = ["Spectrum", "BinnedSpectrum", "SpectralGrid", "BinnedSpectralGrid"]
 
 _FWHM_TO_SIGMA = 1.0 / (2.0 * np.sqrt(2.0 * np.log(2.0)))
 _SAMPLES_PER_FWHM = 10
+_VARIABLE_SAMPLES_PER_FWHM = 20
 _MIN_SAMPLES_PER_FWHM = 2
 # Limit the estimated peak working set for temporary coordinate/flux arrays.
 # Eight float64-sized arrays per temporary point is deliberately conservative.
 _MAX_TEMPORARY_WORKING_BYTES = 512 * 1024**2
 _ESTIMATED_BYTES_PER_TEMPORARY_POINT = 8 * np.dtype(float).itemsize
+_VARIABLE_KERNEL_RADIUS_SIGMA = 4.0
+_ESTIMATED_BYTES_PER_SPARSE_NONZERO = 24
+_MAX_VARIABLE_KERNEL_NONZEROS = 20_000_000
 
 
 def _validate_delta_lambda(delta_lambda):
@@ -67,11 +71,107 @@ def _validate_resolving_power(resolving_power):
     return value
 
 
+def _validate_resolving_power_curve(
+    wavelength,
+    resolving_power,
+    spectrum_wavelength,
+):
+    """Return ascending wavelength and resolving-power profile arrays."""
+    if not isinstance(wavelength, u.Quantity):
+        raise TypeError(
+            "wavelength must be an astropy Quantity with wavelength units"
+        )
+    if not wavelength.unit.is_equivalent(u.AA):
+        raise u.UnitsError("wavelength must have wavelength units")
+
+    curve_wavelength = np.asarray(wavelength.to_value(u.AA))
+    if curve_wavelength.ndim != 1 or curve_wavelength.size < 2:
+        raise ValueError("wavelength must be a one-dimensional array")
+    if np.issubdtype(curve_wavelength.dtype, np.bool_) or np.iscomplexobj(
+        curve_wavelength
+    ):
+        raise TypeError("wavelength must contain real values")
+    try:
+        curve_wavelength = curve_wavelength.astype(float)
+    except (TypeError, ValueError) as exc:
+        raise TypeError("wavelength must contain real values") from exc
+    if not np.all(np.isfinite(curve_wavelength)):
+        raise ValueError("wavelength must contain only finite values")
+    if np.any(curve_wavelength <= 0):
+        raise ValueError("wavelength must contain only positive values")
+
+    differences = np.diff(curve_wavelength)
+    if np.all(differences > 0):
+        pass
+    elif np.all(differences < 0):
+        curve_wavelength = curve_wavelength[::-1]
+    else:
+        raise ValueError("wavelength must be strictly monotonic")
+
+    if isinstance(resolving_power, u.Quantity):
+        if not resolving_power.unit.is_equivalent(u.dimensionless_unscaled):
+            raise u.UnitsError("resolving_power must be dimensionless")
+        curve_resolving_power = np.asarray(
+            resolving_power.to_value(u.dimensionless_unscaled)
+        )
+    else:
+        curve_resolving_power = np.asarray(resolving_power)
+
+    if curve_resolving_power.ndim != 1:
+        raise ValueError("resolving_power must be a one-dimensional array")
+    if curve_resolving_power.shape != curve_wavelength.shape:
+        raise ValueError("wavelength and resolving_power must have matching shapes")
+    if np.issubdtype(curve_resolving_power.dtype, np.bool_):
+        raise TypeError("resolving_power must contain real values")
+    if np.iscomplexobj(curve_resolving_power):
+        raise TypeError("resolving_power must contain real values")
+    try:
+        curve_resolving_power = curve_resolving_power.astype(float)
+    except (TypeError, ValueError) as exc:
+        raise TypeError("resolving_power must contain real values") from exc
+    if not np.all(np.isfinite(curve_resolving_power)):
+        raise ValueError("resolving_power must contain only finite values")
+    if np.any(curve_resolving_power <= 0):
+        raise ValueError("resolving_power must contain only positive values")
+
+    if differences[0] < 0:
+        curve_resolving_power = curve_resolving_power[::-1]
+
+    spectrum_values = np.asarray(spectrum_wavelength.to_value(u.AA), dtype=float)
+    spectrum_minimum = np.min(spectrum_values)
+    spectrum_maximum = np.max(spectrum_values)
+    spectrum_ascending = np.sort(spectrum_values)
+    blue_tolerance = 1e-6 * (
+        spectrum_ascending[1] - spectrum_ascending[0]
+    )
+    red_tolerance = 1e-6 * (
+        spectrum_ascending[-1] - spectrum_ascending[-2]
+    )
+    blue_gap = curve_wavelength[0] - spectrum_minimum
+    red_gap = spectrum_maximum - curve_wavelength[-1]
+    if 0.0 < blue_gap <= blue_tolerance:
+        curve_wavelength[0] = spectrum_minimum
+        blue_gap = 0.0
+    if 0.0 < red_gap <= red_tolerance:
+        curve_wavelength[-1] = spectrum_maximum
+        red_gap = 0.0
+    misses_blue_edge = blue_gap > 0.0
+    misses_red_edge = red_gap > 0.0
+    if misses_blue_edge or misses_red_edge:
+        raise ValueError(
+            "The resolving-power curve must cover the full wavelength range "
+            "of the input spectrum; extrapolation is not supported"
+        )
+
+    return curve_wavelength, curve_resolving_power
+
+
 def _build_gaussian_convolution_plan(
     wavelength,
     *,
     delta_lambda=None,
     resolving_power=None,
+    validate_sampling=True,
 ):
     """Build reusable coordinate and kernel information for Gaussian smoothing."""
     if (delta_lambda is None) == (resolving_power is None):
@@ -108,7 +208,7 @@ def _build_gaussian_convolution_plan(
     coordinate_differences = np.diff(coordinate)
     maximum_spacing = np.max(coordinate_differences)
     required_fwhm = _MIN_SAMPLES_PER_FWHM * maximum_spacing
-    if coordinate_fwhm < required_fwhm:
+    if validate_sampling and coordinate_fwhm < required_fwhm:
         resolution_name = (
             "resolving power" if logarithmic else "wavelength resolution"
         )
@@ -172,6 +272,298 @@ def _build_gaussian_convolution_plan(
     }
 
 
+def _build_variable_resolving_power_plan(
+    wavelength,
+    curve_wavelength,
+    curve_resolving_power,
+):
+    """Build a Gaussian convolution plan for sampled resolving power."""
+    if np.all(curve_resolving_power == curve_resolving_power[0]):
+        return _build_gaussian_convolution_plan(
+            wavelength,
+            resolving_power=curve_resolving_power[0],
+        )
+
+    wave = np.asarray(wavelength.to_value(u.AA), dtype=float)
+    if wave.ndim != 1 or wave.size < 2:
+        raise ValueError("The wavelength axis must contain at least two points")
+    if not np.all(np.isfinite(wave)):
+        raise ValueError("The wavelength axis must contain only finite values")
+
+    differences = np.diff(wave)
+    if np.all(differences > 0):
+        order = np.arange(wave.size)
+    elif np.all(differences < 0):
+        order = np.arange(wave.size - 1, -1, -1)
+    else:
+        raise ValueError("The wavelength axis must be strictly monotonic")
+
+    wave_ascending = wave[order]
+    if np.any(wave_ascending <= 0):
+        raise ValueError(
+            "Wavelengths must be positive for resolving-power convolution"
+        )
+    coordinate = np.log(wave_ascending)
+    coordinate_differences = np.diff(coordinate)
+
+    resolving_power_at_samples = np.interp(
+        wave_ascending,
+        curve_wavelength,
+        curve_resolving_power,
+    )
+    maximum_interval_resolving_power = np.maximum(
+        resolving_power_at_samples[:-1],
+        resolving_power_at_samples[1:],
+    )
+    interior_curve = (
+        (curve_wavelength > wave_ascending[0])
+        & (curve_wavelength < wave_ascending[-1])
+    )
+    interior_indices = np.searchsorted(
+        wave_ascending,
+        curve_wavelength[interior_curve],
+        side="right",
+    ) - 1
+    valid_indices = interior_indices < maximum_interval_resolving_power.size
+    np.maximum.at(
+        maximum_interval_resolving_power,
+        interior_indices[valid_indices],
+        curve_resolving_power[interior_curve][valid_indices],
+    )
+
+    interval_fwhm = 2.0 * np.arcsinh(
+        1.0 / (2.0 * maximum_interval_resolving_power)
+    )
+    under_sampled = interval_fwhm < (
+        _MIN_SAMPLES_PER_FWHM * coordinate_differences
+    )
+    if np.any(under_sampled):
+        index = np.flatnonzero(under_sampled)[0]
+        raise ValueError(
+            "Requested resolving power is under-sampled by the input grid "
+            f"near {wave_ascending[index]:.6g} Angstrom: the target FWHM "
+            f"in log wavelength is {interval_fwhm[index]:.6g}, but at least "
+            f"{_MIN_SAMPLES_PER_FWHM * coordinate_differences[index]:.6g} "
+            f"is required for {_MIN_SAMPLES_PER_FWHM} samples per FWHM."
+        )
+
+    curve_in_range = (
+        (curve_wavelength > wave_ascending[0])
+        & (curve_wavelength < wave_ascending[-1])
+    )
+    metric_wavelength = np.unique(
+        np.concatenate(
+            (wave_ascending, curve_wavelength[curve_in_range])
+        )
+    )
+    metric_coordinate = np.log(metric_wavelength)
+    metric_resolving_power = np.interp(
+        metric_wavelength,
+        curve_wavelength,
+        curve_resolving_power,
+    )
+    metric_fwhm = 2.0 * np.arcsinh(
+        1.0 / (2.0 * metric_resolving_power)
+    )
+    resolution_coordinate = np.zeros(metric_coordinate.size)
+    resolution_coordinate[1:] = np.cumsum(
+        0.5
+        * (1.0 / metric_fwhm[:-1] + 1.0 / metric_fwhm[1:])
+        * np.diff(metric_coordinate)
+    )
+    interval_count_float = (
+        _VARIABLE_SAMPLES_PER_FWHM * resolution_coordinate[-1]
+    )
+    maximum_temporary_points = (
+        _MAX_TEMPORARY_WORKING_BYTES
+        // _ESTIMATED_BYTES_PER_TEMPORARY_POINT
+    )
+    if (
+        not np.isfinite(interval_count_float)
+        or interval_count_float + 1 > maximum_temporary_points
+    ):
+        estimated_mib = (
+            (interval_count_float + 1)
+            * _ESTIMATED_BYTES_PER_TEMPORARY_POINT
+            / 1024**2
+        )
+        raise ValueError(
+            "Variable resolving-power convolution is impractical: the "
+            f"adaptive grid alone requires an estimated {estimated_mib:.1f} "
+            "MiB working set, exceeding the "
+            f"{_MAX_TEMPORARY_WORKING_BYTES / 1024**2:.0f} MiB safety limit."
+        )
+
+    interval_count = max(1, int(np.ceil(interval_count_float)))
+    adaptive_resolution_coordinate = np.linspace(
+        0.0,
+        resolution_coordinate[-1],
+        interval_count + 1,
+    )
+    adaptive_edges = np.interp(
+        adaptive_resolution_coordinate,
+        resolution_coordinate,
+        metric_coordinate,
+    )
+    adaptive_centers = 0.5 * (adaptive_edges[:-1] + adaptive_edges[1:])
+
+    coordinate_fwhm = 2.0 * np.arcsinh(
+        1.0 / (2.0 * resolving_power_at_samples)
+    )
+    sigma = coordinate_fwhm * _FWHM_TO_SIGMA
+    support = _VARIABLE_KERNEL_RADIUS_SIGMA * sigma
+    starts = np.searchsorted(
+        adaptive_edges,
+        coordinate - support,
+        side="right",
+    ) - 1
+    stops = np.searchsorted(
+        adaptive_edges,
+        coordinate + support,
+        side="left",
+    )
+    starts = np.clip(starts, 0, adaptive_centers.size - 1)
+    stops = np.clip(stops, 1, adaptive_centers.size)
+    counts = stops - starts
+    kernel_nonzeros = int(np.sum(counts, dtype=np.int64))
+    remap_nonzeros = 2 * wave_ascending.size
+    estimated_bytes = (
+        kernel_nonzeros * _ESTIMATED_BYTES_PER_SPARSE_NONZERO
+        + remap_nonzeros * _ESTIMATED_BYTES_PER_SPARSE_NONZERO
+        + (
+            wave_ascending.size
+            + adaptive_edges.size
+            + metric_coordinate.size
+        )
+        * _ESTIMATED_BYTES_PER_TEMPORARY_POINT
+    )
+    if (
+        kernel_nonzeros > _MAX_VARIABLE_KERNEL_NONZEROS
+        or estimated_bytes > _MAX_TEMPORARY_WORKING_BYTES
+    ):
+        raise ValueError(
+            "Variable resolving-power convolution is impractical: the "
+            f"estimated plan has {kernel_nonzeros:,} Gaussian weights and "
+            f"requires {estimated_bytes / 1024**2:.1f} MiB, exceeding the "
+            "work or memory safety limit. Supply a more compact spectrum or "
+            "a more smoothly varying resolving-power curve."
+        )
+
+    from scipy.sparse import csc_matrix
+    from scipy.special import ndtr
+
+    indptr = np.empty(wave_ascending.size + 1, dtype=np.int64)
+    indptr[0] = 0
+    np.cumsum(counts, out=indptr[1:])
+    indices = np.empty(kernel_nonzeros, dtype=np.int32)
+    weights = np.empty(kernel_nonzeros, dtype=float)
+    for source_index, (start, stop) in enumerate(zip(starts, stops)):
+        destination_indices = np.arange(start, stop, dtype=np.int32)
+        data_start = indptr[source_index]
+        data_stop = indptr[source_index + 1]
+        indices[data_start:data_stop] = destination_indices
+        edge_offsets = (
+            adaptive_edges[start : stop + 1] - coordinate[source_index]
+        ) / sigma[source_index]
+        source_weights = np.diff(ndtr(edge_offsets))
+        source_weights /= np.sum(source_weights)
+        weights[data_start:data_stop] = source_weights
+
+    kernel_matrix = csc_matrix(
+        (weights, indices, indptr),
+        shape=(adaptive_centers.size, wave_ascending.size),
+    )
+
+    input_edges = np.empty(wave_ascending.size + 1)
+    input_edges[0] = coordinate[0]
+    input_edges[-1] = coordinate[-1]
+    input_edges[1:-1] = 0.5 * (coordinate[:-1] + coordinate[1:])
+    input_widths = np.diff(input_edges)
+    adaptive_widths = np.diff(adaptive_edges)
+    output_matrix = _build_density_interpolation_matrix(
+        adaptive_centers,
+        adaptive_widths,
+        coordinate,
+        input_widths,
+    )
+    adaptive_coverage = np.asarray(output_matrix.sum(axis=0)).reshape(-1)
+    source_coverage = np.asarray(adaptive_coverage @ kernel_matrix).reshape(-1)
+    source_normalization = 1.0 / source_coverage
+
+    return {
+        "coordinate": coordinate,
+        "input_widths": input_widths,
+        "kernel_matrix": kernel_matrix,
+        "logarithmic": True,
+        "order": order,
+        "output_matrix": output_matrix,
+        "source_normalization": source_normalization,
+        "variable": True,
+        "wave_ascending": wave_ascending,
+    }
+
+
+def _build_density_interpolation_matrix(
+    source_coordinate,
+    source_widths,
+    destination_coordinate,
+    destination_widths,
+):
+    """Return a sparse linear interpolation from source to destination mass."""
+    from scipy.sparse import csr_matrix
+
+    upper_indices = np.searchsorted(
+        source_coordinate,
+        destination_coordinate,
+        side="right",
+    )
+    interior = (upper_indices > 0) & (
+        upper_indices < source_coordinate.size
+    )
+    row_counts = np.where(interior, 2, 1)
+    indptr = np.empty(destination_coordinate.size + 1, dtype=np.int64)
+    indptr[0] = 0
+    np.cumsum(row_counts, out=indptr[1:])
+    indices = np.empty(indptr[-1], dtype=np.int32)
+    weights = np.empty(indptr[-1], dtype=float)
+
+    row_starts = indptr[:-1]
+    blue = upper_indices == 0
+    red = upper_indices == source_coordinate.size
+    indices[row_starts[blue]] = 0
+    weights[row_starts[blue]] = (
+        destination_widths[blue] / source_widths[0]
+    )
+    indices[row_starts[red]] = source_coordinate.size - 1
+    weights[row_starts[red]] = (
+        destination_widths[red] / source_widths[-1]
+    )
+
+    upper = upper_indices[interior]
+    lower = upper - 1
+    fractions = (
+        destination_coordinate[interior] - source_coordinate[lower]
+    ) / (source_coordinate[upper] - source_coordinate[lower])
+    starts = row_starts[interior]
+    indices[starts] = lower
+    indices[starts + 1] = upper
+    weights[starts] = (
+        destination_widths[interior]
+        * (1.0 - fractions)
+        / source_widths[lower]
+    )
+    weights[starts + 1] = (
+        destination_widths[interior]
+        * fractions
+        / source_widths[upper]
+    )
+
+    return csr_matrix(
+        (weights, indices, indptr),
+        shape=(destination_coordinate.size, source_coordinate.size),
+    )
+
+
 def _apply_gaussian_convolution_plan(flux, plan):
     """Apply a prepared Gaussian convolution plan to one flux vector."""
     from astropy.convolution import Gaussian1DKernel, convolve
@@ -183,6 +575,21 @@ def _apply_gaussian_convolution_plan(flux, plan):
         )
 
     values_ascending = values[plan["order"]]
+    if plan.get("variable", False):
+        density = plan["wave_ascending"] * values_ascending
+        source_mass = (
+            density
+            * plan["input_widths"]
+            * plan["source_normalization"]
+        )
+        adaptive_mass = plan["kernel_matrix"] @ source_mass
+        output_mass = plan["output_matrix"] @ adaptive_mass
+        output_density = output_mass / plan["input_widths"]
+        output_ascending = output_density / plan["wave_ascending"]
+        output = np.empty_like(output_ascending)
+        output[plan["order"]] = output_ascending
+        return output
+
     if plan["logarithmic"]:
         # d(lambda) = lambda d(ln(lambda)), so lambda * F_lambda is the
         # appropriate density to convolve when preserving wavelength-integrated
@@ -930,6 +1337,55 @@ class Spectrum(Spectrum1D):
             meta=copy.deepcopy(self.meta),
         )
 
+    def set_variable_resolving_power(self, wavelength, resolving_power):
+        """Return a spectrum broadened to wavelength-dependent resolving power.
+
+        Parameters
+        ----------
+        wavelength : `~astropy.units.Quantity`
+            Strictly monotonic wavelengths sampling the resolving-power curve.
+            The curve must cover the full wavelength range of the spectrum.
+        resolving_power : array-like or `~astropy.units.Quantity`
+            Positive dimensionless resolving power values corresponding to
+            ``wavelength``.
+
+        Returns
+        -------
+        spec_new : `~speclib.Spectrum`
+            A new spectrum on the original spectral axis. The input spectrum is
+            not modified.
+
+        Notes
+        -----
+        Resolving power is linearly interpolated between the supplied samples;
+        extrapolation is not supported. The curve is intended to vary smoothly
+        relative to the local resolution element. Each input wavelength is
+        broadened by a source-centered Gaussian using the wavelength-coordinate
+        and flux conventions of :meth:`set_spectral_resolving_power`. The
+        intrinsic input line width is assumed negligible, and the output
+        wavelength sampling is unchanged. Operations whose estimated sparse
+        plan exceeds the work or memory safety limit are rejected.
+        """
+        _validate_spectrum_convolution_state(self)
+        curve_wavelength, curve_resolving_power = (
+            _validate_resolving_power_curve(
+                wavelength,
+                resolving_power,
+                self.wavelength,
+            )
+        )
+        plan = _build_variable_resolving_power_plan(
+            self.wavelength,
+            curve_wavelength,
+            curve_resolving_power,
+        )
+        convolved_flux = _apply_gaussian_convolution_plan(self.flux.value, plan)
+        return Spectrum(
+            spectral_axis=self.spectral_axis.copy(),
+            flux=convolved_flux * self.flux.unit,
+            meta=copy.deepcopy(self.meta),
+        )
+
     @u.quantity_input(center=u.AA, width=u.AA)
     def bin(self, center, width):
         """
@@ -1360,6 +1816,46 @@ class SpectralGrid(object):
         plan = _build_gaussian_convolution_plan(
             self.wavelength,
             resolving_power=resolving_power_value,
+        )
+        return self._with_gaussian_convolution(plan)
+
+    def set_variable_resolving_power(self, wavelength, resolving_power):
+        """Return a new grid with wavelength-dependent resolving power.
+
+        Parameters
+        ----------
+        wavelength : `~astropy.units.Quantity`
+            Strictly monotonic wavelengths sampling the resolving-power curve.
+            The curve must cover the full grid wavelength range.
+        resolving_power : array-like or `~astropy.units.Quantity`
+            Positive dimensionless resolving power values corresponding to
+            ``wavelength``.
+
+        Returns
+        -------
+        grid_new : `~speclib.SpectralGrid`
+            A new grid containing the convolved spectra.
+
+        Notes
+        -----
+        The same variable-width convolution plan is reused for every stored
+        spectrum. The original grid and its wavelength sampling are unchanged.
+        Other conventions and limitations match
+        :meth:`Spectrum.set_variable_resolving_power`.
+        """
+        if self.wavelength is None or not self.points.size:
+            raise ValueError("SpectralGrid contains no spectra")
+        curve_wavelength, curve_resolving_power = (
+            _validate_resolving_power_curve(
+                wavelength,
+                resolving_power,
+                self.wavelength,
+            )
+        )
+        plan = _build_variable_resolving_power_plan(
+            self.wavelength,
+            curve_wavelength,
+            curve_resolving_power,
         )
         return self._with_gaussian_convolution(plan)
 

--- a/tests/test_resolution.py
+++ b/tests/test_resolution.py
@@ -3,9 +3,11 @@ import numpy as np
 import pytest
 from astropy.nddata import StdDevUncertainty
 from scipy.interpolate import NearestNDInterpolator
+from scipy.special import ndtr
 
 from speclib import Spectrum
 from speclib import utils
+from speclib import core
 from speclib.core import SpectralGrid
 
 
@@ -54,6 +56,31 @@ def _line_area_and_centroid(wavelength, flux):
     area = np.trapezoid(flux, wavelength)
     centroid = np.trapezoid(wavelength * flux, wavelength) / area
     return area, centroid
+
+
+def _direct_variable_resolving_power(wavelength, flux, curve_wave, curve_r):
+    """Small independent finite-volume reference for variable-R tests."""
+    coordinate = np.log(wavelength)
+    edges = np.empty(coordinate.size + 1)
+    edges[0] = coordinate[0]
+    edges[-1] = coordinate[-1]
+    edges[1:-1] = 0.5 * (coordinate[:-1] + coordinate[1:])
+    widths = np.diff(edges)
+    resolving_power = np.interp(wavelength, curve_wave, curve_r)
+    sigma = (
+        2.0
+        * np.arcsinh(1.0 / (2.0 * resolving_power))
+        / (2.0 * np.sqrt(2.0 * np.log(2.0)))
+    )
+    source_mass = wavelength * flux * widths
+    output_mass = np.zeros(wavelength.size)
+    for source_index in range(wavelength.size):
+        probabilities = np.diff(
+            ndtr((edges - coordinate[source_index]) / sigma[source_index])
+        )
+        probabilities /= probabilities.sum()
+        output_mass += source_mass[source_index] * probabilities
+    return output_mass / widths / wavelength
 
 
 def _make_grid():
@@ -125,6 +152,126 @@ def test_spectrum_set_spectral_resolving_power_has_constant_r():
     assert result is not spectrum
 
 
+def test_spectrum_set_variable_resolving_power_follows_sampled_curve():
+    spectrum = _synthetic_spectrum()
+    curve_wavelength = np.array([4300.0, 5000.0, 5800.0, 6700.0]) * u.AA
+    curve_resolving_power = np.array([900.0, 1800.0, 1200.0, 2200.0])
+
+    result = spectrum.set_variable_resolving_power(
+        curve_wavelength,
+        curve_resolving_power,
+    )
+
+    widths = np.array(
+        [
+            _measure_fwhm(result.wavelength.value, result.flux.value, center)
+            for center in LINE_CENTERS
+        ]
+    )
+    expected = np.interp(
+        LINE_CENTERS,
+        curve_wavelength.value,
+        curve_resolving_power,
+    )
+    np.testing.assert_allclose(LINE_CENTERS / widths, expected, rtol=0.03)
+    np.testing.assert_array_equal(result.spectral_axis, spectrum.spectral_axis)
+
+
+def test_constant_variable_resolving_power_matches_constant_method():
+    spectrum = _synthetic_spectrum()
+
+    constant = spectrum.set_spectral_resolving_power(1500.0)
+    variable = spectrum.set_variable_resolving_power(
+        np.array([4300.0, 6700.0]) * u.AA,
+        np.array([1500.0, 1500.0]),
+    )
+
+    np.testing.assert_allclose(variable.flux, constant.flux, rtol=1e-12)
+
+
+def test_variable_resolving_power_preserves_interior_line_flux_and_centroid():
+    wavelength = np.arange(4000.0, 8000.01, 0.05)
+    center = 6000.13
+    flux = np.exp(-0.5 * ((wavelength - center) / 0.08) ** 2)
+    spectrum = Spectrum(
+        spectral_axis=wavelength * u.AA,
+        flux=flux * FLUX_UNIT,
+    )
+
+    result = spectrum.set_variable_resolving_power(
+        np.array([4000.0, 8000.0]) * u.AA,
+        np.array([1000.0, 2000.0]),
+    )
+
+    input_integral, input_centroid = _line_area_and_centroid(wavelength, flux)
+    output_integral, output_centroid = _line_area_and_centroid(
+        wavelength,
+        result.flux.value,
+    )
+    assert output_integral == pytest.approx(input_integral, rel=5e-4)
+    assert output_centroid == pytest.approx(input_centroid, abs=5e-3)
+
+
+def test_variable_resolving_power_matches_direct_source_centered_reference():
+    wavelength = np.linspace(4900.0, 5100.0, 801)
+    center = 5000.13
+    flux = np.exp(-0.5 * ((wavelength - center) / 0.12) ** 2)
+    curve_wavelength = np.array([4900.0, 5000.0, 5100.0])
+    curve_resolving_power = np.array([500.0, 510.0, 505.0])
+    spectrum = Spectrum(
+        spectral_axis=wavelength * u.AA,
+        flux=flux * FLUX_UNIT,
+    )
+
+    result = spectrum.set_variable_resolving_power(
+        curve_wavelength * u.AA,
+        curve_resolving_power,
+    )
+    reference = _direct_variable_resolving_power(
+        wavelength,
+        flux,
+        curve_wavelength,
+        curve_resolving_power,
+    )
+
+    relative_l1_error = np.trapezoid(
+        np.abs(result.flux.value - reference),
+        wavelength,
+    ) / np.trapezoid(reference, wavelength)
+    assert relative_l1_error < 2e-3
+    reference_area, reference_centroid = _line_area_and_centroid(
+        wavelength,
+        reference,
+    )
+    result_area, result_centroid = _line_area_and_centroid(
+        wavelength,
+        result.flux.value,
+    )
+    assert result_area == pytest.approx(reference_area, rel=1e-4)
+    assert result_centroid == pytest.approx(reference_centroid, abs=1e-3)
+
+
+def test_variable_resolving_power_preserves_smooth_interior_continuum():
+    wavelength = np.linspace(4900.0, 5100.0, 2001)
+    spectrum = Spectrum(
+        spectral_axis=wavelength * u.AA,
+        flux=np.ones(wavelength.size) * FLUX_UNIT,
+    )
+
+    result = spectrum.set_variable_resolving_power(
+        np.array([4900.0, 5000.0, 5100.0]) * u.AA,
+        np.array([500.0, 510.0, 520.0]),
+    )
+
+    interior = (wavelength > 4940.0) & (wavelength < 5060.0)
+    np.testing.assert_allclose(
+        result.flux.value[interior],
+        1.0,
+        rtol=5e-4,
+        atol=0.0,
+    )
+
+
 def test_phase_shifted_lines_preserve_centroids():
     wavelength = np.arange(4900.0, 5100.001, 0.01)
     input_sigma = 0.02
@@ -185,6 +332,28 @@ def test_edge_line_has_no_interior_flux_guarantee():
     assert output_integral < 0.8 * input_integral
 
 
+def test_variable_resolving_power_has_finite_flux_conserving_edge_behavior():
+    wavelength = np.arange(5000.0, 5100.001, 0.05)
+    flux = np.exp(-0.5 * ((wavelength - 5000.2) / 0.03) ** 2)
+    spectrum = Spectrum(
+        spectral_axis=wavelength * u.AA,
+        flux=flux * FLUX_UNIT,
+    )
+
+    result = spectrum.set_variable_resolving_power(
+        np.array([5000.0, 5100.0]) * u.AA,
+        np.array([500.0, 520.0]),
+    )
+
+    assert np.all(np.isfinite(result.flux.value))
+    input_integral, _ = _line_area_and_centroid(wavelength, flux)
+    output_integral, _ = _line_area_and_centroid(
+        wavelength,
+        result.flux.value,
+    )
+    assert output_integral == pytest.approx(input_integral, rel=1e-4)
+
+
 def test_spectrum_resolution_methods_support_descending_wavelengths():
     spectrum = _synthetic_spectrum()
     descending = Spectrum(
@@ -194,6 +363,35 @@ def test_spectrum_resolution_methods_support_descending_wavelengths():
 
     ascending_result = spectrum.set_spectral_resolving_power(1500.0)
     descending_result = descending.set_spectral_resolving_power(1500.0)
+
+    np.testing.assert_array_equal(
+        descending_result.spectral_axis,
+        descending.spectral_axis,
+    )
+    np.testing.assert_allclose(
+        descending_result.flux[::-1],
+        ascending_result.flux,
+        rtol=1e-12,
+    )
+
+
+def test_variable_resolving_power_supports_descending_axes_and_curves():
+    spectrum = _synthetic_spectrum()
+    curve_wavelength = np.array([4300.0, 5000.0, 5800.0, 6700.0]) * u.AA
+    curve_resolving_power = np.array([900.0, 1800.0, 1200.0, 2200.0])
+    descending = Spectrum(
+        spectral_axis=spectrum.spectral_axis[::-1].copy(),
+        flux=spectrum.flux[::-1].copy(),
+    )
+
+    ascending_result = spectrum.set_variable_resolving_power(
+        curve_wavelength,
+        curve_resolving_power,
+    )
+    descending_result = descending.set_variable_resolving_power(
+        curve_wavelength[::-1],
+        curve_resolving_power[::-1],
+    )
 
     np.testing.assert_array_equal(
         descending_result.spectral_axis,
@@ -217,6 +415,16 @@ def test_spectrum_resolution_methods_return_independent_objects():
     assert spectrum.spectral_axis[0] != result.spectral_axis[0]
     assert spectrum.meta["nested"]["value"] == 1
 
+    variable_result = spectrum.set_variable_resolving_power(
+        np.array([4300.0, 6700.0]) * u.AA,
+        np.array([1400.0, 1600.0]),
+    )
+    variable_result.spectral_axis[0] = 4100.0 * u.AA
+    variable_result.meta["nested"]["value"] = 3
+
+    assert spectrum.spectral_axis[0] != variable_result.spectral_axis[0]
+    assert spectrum.meta["nested"]["value"] == 1
+
 
 def test_spectrum_resolution_methods_reject_masks_and_uncertainties():
     spectrum = _synthetic_spectrum()
@@ -235,6 +443,16 @@ def test_spectrum_resolution_methods_reject_masks_and_uncertainties():
         masked.set_spectral_resolution(4.0 * u.AA)
     with pytest.raises(NotImplementedError, match="uncertainties"):
         uncertain.set_spectral_resolving_power(1500.0)
+    with pytest.raises(NotImplementedError, match="masked"):
+        masked.set_variable_resolving_power(
+            np.array([4300.0, 6700.0]) * u.AA,
+            np.array([1400.0, 1600.0]),
+        )
+    with pytest.raises(NotImplementedError, match="uncertainties"):
+        uncertain.set_variable_resolving_power(
+            np.array([4300.0, 6700.0]) * u.AA,
+            np.array([1400.0, 1600.0]),
+        )
 
 
 def test_spectrum_rejects_under_sampled_wavelength_resolution():
@@ -262,6 +480,20 @@ def test_spectrum_rejects_under_sampled_resolving_power():
         spectrum.set_spectral_resolving_power(3000.0)
 
 
+def test_spectrum_rejects_locally_under_sampled_variable_resolving_power():
+    wavelength = np.arange(5000.0, 5101.0, 1.0)
+    spectrum = Spectrum(
+        spectral_axis=wavelength * u.AA,
+        flux=np.ones(wavelength.size) * FLUX_UNIT,
+    )
+
+    with pytest.raises(ValueError, match="under-sampled"):
+        spectrum.set_variable_resolving_power(
+            np.array([5000.0, 5100.0]) * u.AA,
+            np.array([1000.0, 3000.0]),
+        )
+
+
 def test_spectrum_rejects_impractical_temporary_grid():
     wavelength = 5000.0 + np.concatenate(
         ([0.0, 1e-8], np.arange(1.0, 101.0))
@@ -273,6 +505,16 @@ def test_spectrum_rejects_impractical_temporary_grid():
 
     with pytest.raises(ValueError, match="safety limit"):
         spectrum.set_spectral_resolution(3.0 * u.AA)
+
+
+def test_variable_resolving_power_rejects_impractical_sparse_plan(monkeypatch):
+    monkeypatch.setattr(core, "_MAX_VARIABLE_KERNEL_NONZEROS", 10)
+
+    with pytest.raises(ValueError, match="work or memory safety limit"):
+        _synthetic_spectrum().set_variable_resolving_power(
+            np.array([4300.0, 6700.0]) * u.AA,
+            np.array([1400.0, 1600.0]),
+        )
 
 
 @pytest.mark.parametrize("value", [0.0 * u.AA, -1.0 * u.AA, np.nan * u.AA])
@@ -297,6 +539,96 @@ def test_spectrum_resolution_methods_reject_invalid_units_and_shapes():
         spectrum.set_spectral_resolving_power(1500.0 * u.AA)
     with pytest.raises(ValueError):
         spectrum.set_spectral_resolving_power(np.array([1000.0, 1500.0]))
+
+
+def test_variable_resolving_power_rejects_invalid_curve_inputs():
+    spectrum = _synthetic_spectrum()
+    valid_wavelength = np.array([4300.0, 6700.0]) * u.AA
+
+    with pytest.raises(TypeError, match="astropy Quantity"):
+        spectrum.set_variable_resolving_power(
+            np.array([4300.0, 6700.0]),
+            np.array([1000.0, 1500.0]),
+        )
+    with pytest.raises(u.UnitsError, match="wavelength units"):
+        spectrum.set_variable_resolving_power(
+            np.array([1.0, 2.0]) * u.s,
+            np.array([1000.0, 1500.0]),
+        )
+    with pytest.raises(ValueError, match="matching shapes"):
+        spectrum.set_variable_resolving_power(
+            valid_wavelength,
+            np.array([1000.0]),
+        )
+    with pytest.raises(ValueError, match="strictly monotonic"):
+        spectrum.set_variable_resolving_power(
+            np.array([4300.0, 5000.0, 4900.0, 6700.0]) * u.AA,
+            np.array([1000.0, 1200.0, 1300.0, 1500.0]),
+        )
+    with pytest.raises(ValueError, match="positive values"):
+        spectrum.set_variable_resolving_power(
+            valid_wavelength,
+            np.array([1000.0, 0.0]),
+        )
+    with pytest.raises(u.UnitsError, match="dimensionless"):
+        spectrum.set_variable_resolving_power(
+            valid_wavelength,
+            np.array([1000.0, 1500.0]) * u.AA,
+        )
+    with pytest.raises(TypeError, match="real values"):
+        spectrum.set_variable_resolving_power(
+            np.array([4300.0 + 1.0j, 6700.0]) * u.AA,
+            np.array([1000.0, 1500.0]),
+        )
+    with pytest.raises(TypeError, match="real values"):
+        spectrum.set_variable_resolving_power(
+            valid_wavelength,
+            np.array([1000.0 + 1.0j, 1500.0]),
+        )
+    with pytest.raises(ValueError, match="finite values"):
+        spectrum.set_variable_resolving_power(
+            valid_wavelength,
+            np.array([1000.0, np.inf]),
+        )
+    with pytest.raises(ValueError, match="strictly monotonic"):
+        spectrum.set_variable_resolving_power(
+            np.array([4300.0, 4300.0, 6700.0]) * u.AA,
+            np.array([1000.0, 1200.0, 1500.0]),
+        )
+    with pytest.raises(ValueError, match="finite values"):
+        spectrum.set_variable_resolving_power(
+            np.array([4300.0, np.nan]) * u.AA,
+            np.array([1000.0, 1500.0]),
+        )
+    with pytest.raises(TypeError, match="real values"):
+        spectrum.set_variable_resolving_power(
+            valid_wavelength,
+            np.array([True, False]),
+        )
+
+
+def test_variable_resolving_power_rejects_incomplete_curve_coverage():
+    spectrum = _synthetic_spectrum()
+
+    with pytest.raises(ValueError, match="full wavelength range"):
+        spectrum.set_variable_resolving_power(
+            np.array([4400.0, 6600.0]) * u.AA,
+            np.array([1000.0, 1500.0]),
+        )
+
+
+def test_variable_resolving_power_does_not_hide_material_endpoint_gap():
+    wavelength = 1e10 + np.arange(101.0)
+    spectrum = Spectrum(
+        spectral_axis=wavelength * u.AA,
+        flux=np.ones(wavelength.size) * FLUX_UNIT,
+    )
+
+    with pytest.raises(ValueError, match="full wavelength range"):
+        spectrum.set_variable_resolving_power(
+            np.array([wavelength[0], wavelength[-1] - 1e-3]) * u.AA,
+            np.array([10.0, 10.1]),
+        )
 
 
 @pytest.mark.parametrize(
@@ -372,6 +704,47 @@ def test_spectral_grid_result_has_independent_mutable_state():
     np.testing.assert_array_equal(grid.points, original_points)
     np.testing.assert_array_equal(grid.teffs, original_teffs)
     np.testing.assert_array_equal(grid.fluxes[3000.0][4.0][0.0], original_flux)
+
+
+def test_spectral_grid_variable_resolving_power_matches_spectrum_method():
+    grid = _make_grid()
+    original_data = grid.data.copy()
+    original_fluxes = [
+        grid.fluxes[teff][logg][feh].value.copy()
+        for teff, logg, feh in grid.points
+    ]
+    curve_wavelength = np.array([4300.0, 5000.0, 5800.0, 6700.0]) * u.AA
+    curve_resolving_power = np.array([900.0, 1800.0, 1200.0, 2200.0])
+
+    result = grid.set_variable_resolving_power(
+        curve_wavelength,
+        curve_resolving_power,
+    )
+
+    expected = Spectrum(
+        spectral_axis=grid.wavelength,
+        flux=grid.fluxes[3000.0][4.0][0.0],
+    ).set_variable_resolving_power(
+        curve_wavelength,
+        curve_resolving_power,
+    )
+    np.testing.assert_allclose(result.data[0], expected.flux.value)
+    np.testing.assert_array_equal(result.wavelength, grid.wavelength)
+    _assert_grid_unchanged(grid, original_data, original_fluxes)
+
+    for row, (teff, logg, feh) in zip(result.data, result.points):
+        expected = Spectrum(
+            spectral_axis=grid.wavelength,
+            flux=grid.fluxes[teff][logg][feh],
+        ).set_variable_resolving_power(
+            curve_wavelength,
+            curve_resolving_power,
+        )
+        np.testing.assert_allclose(row, expected.flux.value)
+        np.testing.assert_array_equal(
+            row,
+            result.fluxes[teff][logg][feh].value,
+        )
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

- add `set_variable_resolving_power()` for `Spectrum` and `SpectralGrid`
- use a reusable, source-centered adaptive Gaussian plan with explicit work and memory guards
- add validation, direct-reference tests, and documentation for the new API

## Testing

- `poetry run pytest` (62 passed)

Closes #69