### PR TITLE
Add SPHINX V4 model grid support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added wavelength-dependent Gaussian resolving-power support for `Spectrum`
   and `SpectralGrid` with `set_variable_resolving_power()`.
+- Added support for loading the SPHINX V4 stellar atmosphere grid from Zenodo
+  through `Spectrum.from_grid()` and `SpectralGrid`.
 
 
 ## [0.1.0b12] - 2026-08-21

--- a/README.md
+++ b/README.md
@@ -80,6 +80,36 @@ download_newera_grid("newera_jwst")
 download_newera_grid("newera_jwst", extract="all")
 ```
 
+### SPHINX I V4
+
+Download and extract the SPHINX I V4 spectra from Zenodo record 11392341:
+
+```python
+from speclib import Spectrum, SpectralGrid, download_sphinx_grid
+
+download_sphinx_grid()
+
+spec = Spectrum.from_grid(
+    teff=3000,
+    logg=4.5,
+    feh=0.0,
+    co_ratio=0.5,
+    model_grid="sphinx",
+)
+
+grid = SpectralGrid(
+    teff_bds=(2800, 3200),
+    logg_bds=(4.0, 5.0),
+    feh_bds=(-0.5, 0.5),
+    co_ratio=0.5,
+    model_grid="sphinx",
+)
+```
+
+SPHINX filenames call the metallicity parameter ``logZ``; it is selected
+through speclib's existing ``feh`` argument. A C/O ratio must be supplied
+explicitly and remains fixed within each three-dimensional ``SpectralGrid``.
+
 ---
 
 ## License

--- a/src/speclib/__init__.py
+++ b/src/speclib/__init__.py
@@ -17,7 +17,12 @@ except PackageNotFoundError:
 
 from .core import Spectrum, BinnedSpectrum, SpectralGrid, BinnedSpectralGrid
 from .photometry import Filter, SED, SEDGrid, apply_filter, mag_to_flux
-from .utils import download_file, download_newera_grid, download_phoenix_grid
+from .utils import (
+    download_file,
+    download_newera_grid,
+    download_phoenix_grid,
+    download_sphinx_grid,
+)
 
 __all__ = [
     "Spectrum",
@@ -32,4 +37,5 @@ __all__ = [
     "download_file",
     "download_phoenix_grid",
     "download_newera_grid",
+    "download_sphinx_grid",
 ]

--- a/src/speclib/core.py
+++ b/src/speclib/core.py
@@ -29,6 +29,47 @@ _ESTIMATED_BYTES_PER_SPARSE_NONZERO = 24
 _MAX_VARIABLE_KERNEL_NONZEROS = 20_000_000
 
 
+def _sphinx_grid_slice(co_ratio):
+    """Return grid axes and exact combinations for one SPHINX C/O slice."""
+
+    if co_ratio is None:
+        raise ValueError(
+            "co_ratio must be specified for the SPHINX I V4 model grid. "
+            "Available values are 0.3, 0.5, 0.7, and 0.9."
+        )
+
+    model_list = utils.load_sphinx_model_list()
+    combinations = model_list["combinations"]
+    combinations = combinations[np.isclose(combinations[:, 3], co_ratio)]
+    if not combinations.size:
+        raise ValueError(
+            f"C/O={co_ratio} is not available in SPHINX I V4. "
+            f"Available values are {model_list['grid_co_ratios'].tolist()}."
+        )
+
+    grid_points = {
+        "grid_teffs": np.unique(combinations[:, 0]),
+        "grid_loggs": np.unique(combinations[:, 1]),
+        "grid_fehs": np.unique(combinations[:, 2]),
+        "grid_co_ratios": model_list["grid_co_ratios"],
+    }
+    return grid_points, combinations
+
+
+def _nearest_sphinx_index(points, requested):
+    """Return the nearest actual SPHINX combination in grid-step units."""
+
+    scales = []
+    for axis in range(3):
+        values = np.unique(points[:, axis])
+        scales.append(np.median(np.diff(values)) if len(values) > 1 else 1.0)
+    distances = np.sum(
+        ((points - np.asarray(requested, dtype=float)) / np.asarray(scales)) ** 2,
+        axis=1,
+    )
+    return int(np.argmin(distances))
+
+
 def _validate_delta_lambda(delta_lambda):
     """Return a positive scalar wavelength FWHM in Angstrom."""
     if not isinstance(delta_lambda, u.Quantity):
@@ -674,7 +715,7 @@ class Spectrum(Spectrum1D):
         logg,
         feh=0,
         alpha=0.0,
-        # CtoO=0.5,
+        co_ratio=None,
         wavelength=None,
         wl_min=None,
         wl_max=None,
@@ -694,7 +735,12 @@ class Spectrum(Spectrum1D):
             Surface gravity of the model in cgs units.
 
         feh : float
-            [Fe/H] of the model.
+            [Fe/H] of the model. For SPHINX this selects the filename's
+            ``logZ`` metallicity parameter.
+
+        co_ratio : float, optional
+            Carbon-to-oxygen ratio. Required when ``model_grid="sphinx"`` and
+            ignored by other model grids.
 
         wavelength : `~astropy.units.Quantity`, optional
             Wavelengths of the interpolated spectrum.
@@ -730,8 +776,13 @@ class Spectrum(Spectrum1D):
                 + str(utils.VALID_MODELS)
             )
 
-        # Define grid points
-        self.grid_points = utils.GRID_POINTS[self.model_grid]
+        # Define grid points. SPHINX is sparse, so derive the selected C/O slice
+        # from the exact filenames in the extracted V4 archive.
+        sphinx_combinations = None
+        if self.model_grid == "sphinx":
+            self.grid_points, sphinx_combinations = _sphinx_grid_slice(co_ratio)
+        else:
+            self.grid_points = utils.GRID_POINTS[self.model_grid]
         self.grid_teffs = self.grid_points["grid_teffs"]
         self.grid_loggs = self.grid_points["grid_loggs"]
         self.grid_fehs = self.grid_points["grid_fehs"]
@@ -1030,25 +1081,33 @@ class Spectrum(Spectrum1D):
                 wave_lib, flux = np.loadtxt(cache_dir / fname, unpack=True)
 
         elif self.model_grid == "sphinx":
-            # Only works if the user has already cached the SPHINX model grid
             lib_wave_unit = u.micron
             lib_flux_unit = u.Unit("W/(m^2 * m)")
-            cache_dir = utils.get_library_root() / "sphinx"
-            cache_dir.mkdir(parents=True, exist_ok=True)
 
-            # CtoO = 0.5  # Not varying this for now
-            # fname_str = "Teff_{:04.1f}_logg_{:0.2f}_logZ_{:+0.2f}_CtoO_{:0.1f}_spectra.txt"
-            fname_str = "Teff_{:04.1f}_logg_{:0.2f}_logZ_{:+0.2f}_CtoO_0.5_spectra.txt"
-
-            def load_wave_flux(fname):
-                path = cache_dir / fname
-                wave, flux = np.loadtxt(path, unpack=True)
-                return wave, flux
+            def load_wave_flux(teff_, logg_, metallicity_):
+                wavelength_, flux_ = utils.load_sphinx_spectrum(
+                    teff_, logg_, metallicity_, co_ratio
+                )
+                return (
+                    wavelength_.to_value(lib_wave_unit),
+                    flux_.to_value(lib_flux_unit),
+                )
 
             teff_in_grid = teff in self.grid_teffs
             logg_in_grid = logg in self.grid_loggs
             feh_in_grid = feh in self.grid_fehs
             model_in_grid = all([teff_in_grid, logg_in_grid, feh_in_grid])
+            requested = np.array([teff, logg, feh], dtype=float)
+            exact_combinations = sphinx_combinations[:, :3]
+            model_in_grid = model_in_grid and np.any(
+                np.all(np.isclose(exact_combinations, requested), axis=1)
+            )
+            if not model_in_grid and not interpolate:
+                nearest_index = _nearest_sphinx_index(
+                    exact_combinations, requested
+                )
+                teff, logg, feh = exact_combinations[nearest_index]
+                model_in_grid = True
             if not model_in_grid:
                 if teff_in_grid:
                     teff_bds = [teff, teff]
@@ -1064,24 +1123,28 @@ class Spectrum(Spectrum1D):
                     feh_bds = utils.find_bounds(self.grid_fehs, feh)
 
                 flux_dict = {}
+                wave_lib = None
                 for tt in teff_bds:
                     flux_dict[tt] = {}
                     for gg in logg_bds:
                         flux_dict[tt][gg] = {}
                         for ff in feh_bds:
-                            fname = fname_str.format(tt, gg, ff)
-                            flux_dict[tt][gg][ff] = np.loadtxt(
-                                cache_dir / fname, unpack=True, usecols=1
-                            )
+                            wavelength_, flux_ = load_wave_flux(tt, gg, ff)
+                            if wave_lib is None:
+                                wave_lib = wavelength_
+                            elif not np.array_equal(wave_lib, wavelength_):
+                                raise ValueError(
+                                    "SPHINX spectra required for interpolation "
+                                    "do not share a wavelength grid."
+                                )
+                            flux_dict[tt][gg][ff] = flux_
 
                 flux = utils.trilinear_interpolate(
                     flux_dict, (teff_bds, logg_bds, feh_bds), (teff, logg, feh)
                 )
 
             elif model_in_grid:
-                # Load the wavelength and flux arrays
-                fname = fname_str.format(teff, logg, feh)
-                wave_lib, flux = load_wave_flux(fname)
+                wave_lib, flux = load_wave_flux(teff, logg, feh)
 
         elif self.model_grid == "mps-atlas":
             # Only works if the user has already cached the MPS-Atlas model grid
@@ -1577,6 +1640,7 @@ class SpectralGrid(object):
         spectral_resolution=None,
         model_grid="phoenix",
         spectral_resolving_power=None,
+        co_ratio=None,
         **kwargs,
     ):
         """
@@ -1602,6 +1666,10 @@ class SpectralGrid(object):
 
         model_grid : str, optional
             Name of the model grid.
+
+        co_ratio : float, optional
+            Fixed carbon-to-oxygen ratio for a SPHINX grid instance. Required
+            for ``model_grid="sphinx"`` and ignored for other grids.
         """
         if (
             spectral_resolution is not None
@@ -1625,8 +1693,11 @@ class SpectralGrid(object):
                 + str(utils.VALID_MODELS)
             )
 
-        # Define grid points
-        self.grid_points = utils.GRID_POINTS[self.model_grid]
+        self.co_ratio = co_ratio
+        if self.model_grid == "sphinx":
+            self.grid_points, _ = _sphinx_grid_slice(co_ratio)
+        else:
+            self.grid_points = utils.GRID_POINTS[self.model_grid]
         self.grid_teffs = self.grid_points["grid_teffs"]
         self.grid_loggs = self.grid_points["grid_loggs"]
         self.grid_fehs = self.grid_points["grid_fehs"]
@@ -1657,6 +1728,9 @@ class SpectralGrid(object):
         points = []
         data = []
         spec = None
+        spectrum_kwargs = dict(kwargs)
+        if self.model_grid == "sphinx":
+            spectrum_kwargs["co_ratio"] = co_ratio
         for teff in self.teffs:
             fluxes[teff] = {}
             for logg in self.loggs:
@@ -1668,7 +1742,7 @@ class SpectralGrid(object):
                             logg,
                             feh,
                             model_grid=self.model_grid,
-                            **kwargs,
+                            **spectrum_kwargs,
                         )
                     except ValueError:
                         # Skip combinations that do not exist in sparse grids
@@ -1900,12 +1974,23 @@ class SpectralGrid(object):
                     message += f"\tInput {p}: {i}. Valid range: {r}\n"
             raise ValueError(message)
 
-        if self.model_grid in ["newera_gaia", "newera_jwst", "newera_lowres"]:
+        if self.model_grid in [
+            "newera_gaia",
+            "newera_jwst",
+            "newera_lowres",
+            "sphinx",
+        ]:
             if self.interpolator is None or not self.points.size:
                 raise ValueError("SpectralGrid contains no spectra")
 
             if not interpolate:
-                flux = self.interpolator((teff, logg, feh))
+                if self.model_grid == "sphinx":
+                    nearest_index = _nearest_sphinx_index(
+                        self.points, (teff, logg, feh)
+                    )
+                    flux = self.data[nearest_index]
+                else:
+                    flux = self.interpolator((teff, logg, feh))
             else:
                 try:
                     flux = utils.trilinear_interpolate(
@@ -1914,6 +1999,11 @@ class SpectralGrid(object):
                         (teff, logg, feh),
                     )
                 except KeyError:
+                    if self.model_grid == "sphinx":
+                        raise ValueError(
+                            "Cannot interpolate this SPHINX point because the "
+                            "selected C/O slice lacks a required corner model."
+                        ) from None
                     # Fall back to nearest-neighbour evaluation for sparse grids
                     flux = self.interpolator((teff, logg, feh))
 
@@ -2042,7 +2132,11 @@ class BinnedSpectralGrid(object):
             )
 
         # Define grid points
-        self.grid_points = utils.GRID_POINTS[self.model_grid]
+        if self.model_grid == "sphinx":
+            co_ratio = kwargs.get("co_ratio")
+            self.grid_points, _ = _sphinx_grid_slice(co_ratio)
+        else:
+            self.grid_points = utils.GRID_POINTS[self.model_grid]
         self.grid_teffs = self.grid_points["grid_teffs"]
         self.grid_loggs = self.grid_points["grid_loggs"]
         self.grid_fehs = self.grid_points["grid_fehs"]

--- a/src/speclib/core.py
+++ b/src/speclib/core.py
@@ -39,21 +39,33 @@ def _sphinx_grid_slice(co_ratio):
         )
 
     model_list = utils.load_sphinx_model_list()
-    combinations = model_list["combinations"]
-    combinations = combinations[np.isclose(combinations[:, 3], co_ratio)]
-    if not combinations.size:
+    available_co_ratios = model_list["grid_co_ratios"]
+    matches = np.flatnonzero(np.isclose(available_co_ratios, co_ratio))
+    if not matches.size:
         raise ValueError(
             f"C/O={co_ratio} is not available in SPHINX I V4. "
-            f"Available values are {model_list['grid_co_ratios'].tolist()}."
+            f"Available values are {available_co_ratios.tolist()}."
         )
+    canonical_co_ratio = float(available_co_ratios[matches[0]])
+    combinations = model_list["combinations"]
+    combinations = combinations[combinations[:, 3] == canonical_co_ratio]
 
     grid_points = {
         "grid_teffs": np.unique(combinations[:, 0]),
         "grid_loggs": np.unique(combinations[:, 1]),
         "grid_fehs": np.unique(combinations[:, 2]),
-        "grid_co_ratios": model_list["grid_co_ratios"],
+        "grid_co_ratios": available_co_ratios,
     }
-    return grid_points, combinations
+    return grid_points, combinations, canonical_co_ratio
+
+
+def _sphinx_flanking_values(grid, value):
+    """Return the true lower and upper SPHINX grid values around a query."""
+
+    grid = np.asarray(grid)
+    lower = grid[grid <= value].max() if np.any(grid <= value) else grid.min()
+    upper = grid[grid >= value].min() if np.any(grid >= value) else grid.max()
+    return np.array([lower, upper])
 
 
 def _nearest_sphinx_index(points, requested):
@@ -715,13 +727,14 @@ class Spectrum(Spectrum1D):
         logg,
         feh=0,
         alpha=0.0,
-        co_ratio=None,
         wavelength=None,
         wl_min=None,
         wl_max=None,
         model_grid="phoenix",
         interpolate=True,
         verbose=False,
+        *,
+        co_ratio=None,
     ):
         """
         Load a model spectrum from a library.
@@ -780,7 +793,9 @@ class Spectrum(Spectrum1D):
         # from the exact filenames in the extracted V4 archive.
         sphinx_combinations = None
         if self.model_grid == "sphinx":
-            self.grid_points, sphinx_combinations = _sphinx_grid_slice(co_ratio)
+            self.grid_points, sphinx_combinations, co_ratio = _sphinx_grid_slice(
+                co_ratio
+            )
         else:
             self.grid_points = utils.GRID_POINTS[self.model_grid]
         self.grid_teffs = self.grid_points["grid_teffs"]
@@ -1112,15 +1127,15 @@ class Spectrum(Spectrum1D):
                 if teff_in_grid:
                     teff_bds = [teff, teff]
                 else:
-                    teff_bds = utils.find_bounds(self.grid_teffs, teff)
+                    teff_bds = _sphinx_flanking_values(self.grid_teffs, teff)
                 if logg_in_grid:
                     logg_bds = [logg, logg]
                 else:
-                    logg_bds = utils.find_bounds(self.grid_loggs, logg)
+                    logg_bds = _sphinx_flanking_values(self.grid_loggs, logg)
                 if feh_in_grid:
                     feh_bds = [feh, feh]
                 else:
-                    feh_bds = utils.find_bounds(self.grid_fehs, feh)
+                    feh_bds = _sphinx_flanking_values(self.grid_fehs, feh)
 
                 flux_dict = {}
                 wave_lib = None
@@ -1695,7 +1710,7 @@ class SpectralGrid(object):
 
         self.co_ratio = co_ratio
         if self.model_grid == "sphinx":
-            self.grid_points, _ = _sphinx_grid_slice(co_ratio)
+            self.grid_points, _, self.co_ratio = _sphinx_grid_slice(co_ratio)
         else:
             self.grid_points = utils.GRID_POINTS[self.model_grid]
         self.grid_teffs = self.grid_points["grid_teffs"]
@@ -1730,7 +1745,7 @@ class SpectralGrid(object):
         spec = None
         spectrum_kwargs = dict(kwargs)
         if self.model_grid == "sphinx":
-            spectrum_kwargs["co_ratio"] = co_ratio
+            spectrum_kwargs["co_ratio"] = self.co_ratio
         for teff in self.teffs:
             fluxes[teff] = {}
             for logg in self.loggs:
@@ -2132,9 +2147,15 @@ class BinnedSpectralGrid(object):
             )
 
         # Define grid points
+        sphinx_combinations = None
         if self.model_grid == "sphinx":
             co_ratio = kwargs.get("co_ratio")
-            self.grid_points, _ = _sphinx_grid_slice(co_ratio)
+            (
+                self.grid_points,
+                sphinx_combinations,
+                self.co_ratio,
+            ) = _sphinx_grid_slice(co_ratio)
+            kwargs["co_ratio"] = self.co_ratio
         else:
             self.grid_points = utils.GRID_POINTS[self.model_grid]
         self.grid_teffs = self.grid_points["grid_teffs"]
@@ -2185,16 +2206,30 @@ class BinnedSpectralGrid(object):
         self.lower = center - width / 2.0
         self.upper = center + width / 2.0
 
-        fluxes = {}
-        for teff in self.teffs:
-            fluxes[teff] = {}
-            for logg in self.loggs:
-                fluxes[teff][logg] = {}
-                for feh in self.fehs:
-                    bs = Spectrum.from_grid(
-                        teff, logg, feh, model_grid=self.model_grid, **kwargs
-                    ).bin(center, width)
-                    fluxes[teff][logg][feh] = bs.flux
+        fluxes = {teff: {logg: {} for logg in self.loggs} for teff in self.teffs}
+        if self.model_grid == "sphinx":
+            within_bounds = (
+                (sphinx_combinations[:, 0] >= self.teff_bds[0])
+                & (sphinx_combinations[:, 0] <= self.teff_bds[1])
+                & (sphinx_combinations[:, 1] >= self.logg_bds[0])
+                & (sphinx_combinations[:, 1] <= self.logg_bds[1])
+                & (sphinx_combinations[:, 2] >= self.feh_bds[0])
+                & (sphinx_combinations[:, 2] <= self.feh_bds[1])
+            )
+            self.points = sphinx_combinations[within_bounds, :3]
+            for teff, logg, feh in self.points:
+                bs = Spectrum.from_grid(
+                    teff, logg, feh, model_grid=self.model_grid, **kwargs
+                ).bin(center, width)
+                fluxes[teff][logg][feh] = bs.flux
+        else:
+            for teff in self.teffs:
+                for logg in self.loggs:
+                    for feh in self.fehs:
+                        bs = Spectrum.from_grid(
+                            teff, logg, feh, model_grid=self.model_grid, **kwargs
+                        ).bin(center, width)
+                        fluxes[teff][logg][feh] = bs.flux
         self.fluxes = fluxes
 
     def get_spectrum(self, teff, logg, feh, interpolate=True):
@@ -2237,6 +2272,29 @@ class BinnedSpectralGrid(object):
                 if not b:
                     message += f"\tInput {p}: {i}. Valid range: {r}\n"
             raise ValueError(message)
+
+        if self.model_grid == "sphinx":
+            if not self.points.size:
+                raise ValueError("BinnedSpectralGrid contains no spectra")
+            if not interpolate:
+                nearest_index = _nearest_sphinx_index(
+                    self.points, (teff, logg, feh)
+                )
+                nearest_teff, nearest_logg, nearest_feh = self.points[
+                    nearest_index
+                ]
+                return self.fluxes[nearest_teff][nearest_logg][nearest_feh]
+            try:
+                return utils.trilinear_interpolate(
+                    self.fluxes,
+                    (self.teffs, self.loggs, self.fehs),
+                    (teff, logg, feh),
+                )
+            except KeyError:
+                raise ValueError(
+                    "Cannot interpolate this SPHINX point because the selected "
+                    "C/O slice lacks a required corner model."
+                ) from None
 
         # If not interpolating, then just return the closest point in the grid.
         if not interpolate:

--- a/src/speclib/utils.py
+++ b/src/speclib/utils.py
@@ -12,19 +12,22 @@ import urllib
 import warnings
 from astropy.io import fits
 from contextlib import closing
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from urllib.error import URLError
 
 __all__ = [
     "download_file",
     "download_phoenix_grid",
     "download_newera_grid",
+    "download_sphinx_grid",
     "get_newera_record_id",
     "load_newera_model_list",
     "find_bounds",
     "interpolate",
     "load_flux_array",
     "load_gaia_format_spectrum",
+    "load_sphinx_model_list",
+    "load_sphinx_spectrum",
     "trilinear_interpolate",
     "nearest",
     "vac2air",
@@ -45,9 +48,18 @@ NEWERA_TARBALLS: dict[str, str] = {
     "newera_lowres": "PHOENIX-NewEraV3-LowRes-SPECTRA.tar.gz",
 }
 
+SPHINX_RECORD_ID = "11392341"
+SPHINX_ARCHIVE_FILENAME = "SPHINX_MAY2024_CLOUDFREE_UPDATED.tar.gz"
+SPHINX_ARCHIVE_HASH = "md5:63d8dd8da5bca66c2384ce3059a29e01"
+SPHINX_ARCHIVE_URL = (
+    f"https://zenodo.org/api/records/{SPHINX_RECORD_ID}/files/"
+    f"{SPHINX_ARCHIVE_FILENAME}/content"
+)
+
 _LIBRARY_ROOT: Path | None = None
 _NEWERA_INDEX_CACHE: dict[tuple[Path, str], dict] = {}
 _NEWERA_TAR_MEMBER_CACHE: dict[Path, dict[str, str]] = {}
+_SPHINX_INDEX_CACHE: dict[Path, dict] = {}
 
 _NEWERA_MODEL_LINE_RE = re.compile(
     r"(?P<filename>"
@@ -58,6 +70,13 @@ _NEWERA_MODEL_LINE_RE = re.compile(
     r"\.PHOENIX-NewEra(?:V[0-9.]+)?-ACES-COND-(?P<year>\d{4})\.HSR\.h5"
     r")",
     re.IGNORECASE,
+)
+
+_SPHINX_MODEL_FILENAME_RE = re.compile(
+    r"^Teff_(?P<teff>\d+(?:\.\d+)?)"
+    r"_logg_(?P<logg>\d+(?:\.\d+)?)"
+    r"_logZ_(?P<metallicity>[+-]\d+(?:\.\d+)?)"
+    r"_CtoO_(?P<co_ratio>\d+(?:\.\d+)?)\.txt$"
 )
 
 
@@ -280,6 +299,164 @@ def _clear_directory(path: Path) -> None:
             shutil.rmtree(child)
         else:
             child.unlink()
+
+
+def _extract_sphinx_spectra(tar_path: Path, cache_dir: Path) -> None:
+    """Safely extract only SPHINX spectrum files from the V4 tarball."""
+
+    cache_root = cache_dir.resolve()
+    with tarfile.open(tar_path, "r:gz") as archive:
+        for member in archive.getmembers():
+            if not member.isfile():
+                continue
+
+            member_path = PurePosixPath(member.name)
+            if (
+                member_path.is_absolute()
+                or ".." in member_path.parts
+                or not _SPHINX_MODEL_FILENAME_RE.fullmatch(member_path.name)
+            ):
+                continue
+
+            target = cache_dir.joinpath(*member_path.parts)
+            if not target.resolve().is_relative_to(cache_root):
+                raise ValueError(f"Unsafe path in SPHINX archive: {member.name}")
+            if target.exists():
+                continue
+
+            source = archive.extractfile(member)
+            if source is None:  # pragma: no cover - guarded by member.isfile()
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with source, open(target, "wb") as destination:
+                shutil.copyfileobj(source, destination)
+
+
+def download_sphinx_grid(
+    overwrite: bool = False,
+    library_root: str | Path | None = None,
+) -> Path:
+    """Download and extract the SPHINX I V4 spectral grid.
+
+    The V4 archive is fetched from Zenodo record 11392341 and verified against
+    the checksum published by Zenodo. Only spectrum ``.txt`` files are
+    extracted; the downloaded tarball remains in the cache.
+
+    Parameters
+    ----------
+    overwrite : bool, optional
+        Remove the existing SPHINX cache before downloading and extracting it.
+    library_root : str or Path, optional
+        Base cache directory. Defaults to :func:`get_library_root`.
+
+    Returns
+    -------
+    Path
+        The SPHINX cache directory.
+    """
+
+    root = get_library_root() if library_root is None else Path(library_root)
+    cache_dir = root.expanduser() / "sphinx"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    if overwrite:
+        _clear_directory(cache_dir)
+
+    archive_path = Path(
+        pooch.retrieve(
+            url=SPHINX_ARCHIVE_URL,
+            fname=SPHINX_ARCHIVE_FILENAME,
+            path=cache_dir,
+            known_hash=SPHINX_ARCHIVE_HASH,
+            processor=None,
+            progressbar=True,
+        )
+    )
+    _extract_sphinx_spectra(archive_path, cache_dir)
+    _SPHINX_INDEX_CACHE.pop(cache_dir.resolve(), None)
+    return cache_dir
+
+
+def _normalize_sphinx_key(
+    teff: float, logg: float, metallicity: float, co_ratio: float
+) -> tuple[float, float, float, float]:
+    return tuple(
+        round(float(value), 8) for value in (teff, logg, metallicity, co_ratio)
+    )
+
+
+def load_sphinx_model_list(
+    *,
+    library_root: str | Path | None = None,
+    cache_dir: str | Path | None = None,
+) -> dict:
+    """Index the exact parameter combinations in an extracted SPHINX I V4 grid."""
+
+    if cache_dir is None:
+        root = get_library_root() if library_root is None else Path(library_root)
+        cache_dir = root.expanduser() / "sphinx"
+    else:
+        cache_dir = Path(cache_dir).expanduser()
+
+    cache_key = cache_dir.resolve()
+    cached = _SPHINX_INDEX_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
+    entries: dict[tuple[float, float, float, float], Path] = {}
+    for path in cache_dir.rglob("*.txt") if cache_dir.exists() else ():
+        match = _SPHINX_MODEL_FILENAME_RE.fullmatch(path.name)
+        if match is None:
+            continue
+        key = _normalize_sphinx_key(
+            match.group("teff"),
+            match.group("logg"),
+            match.group("metallicity"),
+            match.group("co_ratio"),
+        )
+        entries[key] = path
+
+    if not entries:
+        raise FileNotFoundError(
+            f"No extracted SPHINX I V4 spectra found in {cache_dir}. "
+            "Run download_sphinx_grid() first."
+        )
+
+    combinations = np.array(sorted(entries), dtype=float)
+    result = {
+        "entries": entries,
+        "combinations": combinations,
+        "grid_teffs": np.unique(combinations[:, 0]),
+        "grid_loggs": np.unique(combinations[:, 1]),
+        "grid_fehs": np.unique(combinations[:, 2]),
+        "grid_co_ratios": np.unique(combinations[:, 3]),
+    }
+    _SPHINX_INDEX_CACHE[cache_key] = result
+    return result
+
+
+def load_sphinx_spectrum(
+    teff: float,
+    logg: float,
+    metallicity: float,
+    co_ratio: float,
+    *,
+    library_root: str | Path | None = None,
+) -> tuple[u.Quantity, u.Quantity]:
+    """Load one exact SPHINX I V4 model spectrum with physical units."""
+
+    model_list = load_sphinx_model_list(library_root=library_root)
+    key = _normalize_sphinx_key(teff, logg, metallicity, co_ratio)
+    try:
+        path = model_list["entries"][key]
+    except KeyError as exc:
+        raise ValueError(
+            "SPHINX I V4 has no model for "
+            f"Teff={teff}, logg={logg}, logZ={metallicity}, C/O={co_ratio}."
+        ) from exc
+
+    wavelength, flux = np.loadtxt(path, unpack=True)
+    return wavelength * u.micron, flux * (u.W / (u.m**2 * u.m))
 
 
 def download_newera_grid(
@@ -1117,13 +1294,13 @@ GRID_POINTS = {
         "grid_fehs": np.array([-4.0, -3.0, -2.0, -1.5, -1.0, -0.5, -0.0, +0.5, +1.0]),
     },
     "sphinx": {
-        # Grid of effective temperatures
+        # Distinct values found in SPHINX I V4 filenames. The exact available
+        # combinations are indexed from extracted files at runtime.
         "grid_teffs": np.arange(2000.0, 4100.0, 100),
-        # Grid of surface gravities
-        "grid_loggs": np.arange(4.0, 5.75, 0.25),
-        # Grid of metallicities
+        "grid_loggs": np.array(
+            [4.0, 4.2, 4.25, 4.5, 4.7, 4.75, 5.0, 5.2, 5.25, 5.5]
+        ),
         "grid_fehs": np.arange(-1, 1.25, 0.25),
-        # # Grid of CtoOs
-        # 'grid_CtoOs': np.array([0.3, 0.5, 0.7, 0.9]),
+        "grid_co_ratios": np.array([0.3, 0.5, 0.7, 0.9]),
     },
 }

--- a/src/speclib/utils.py
+++ b/src/speclib/utils.py
@@ -8,6 +8,7 @@ import pooch
 import re
 import shutil
 import tarfile
+import tempfile
 import urllib
 import warnings
 from astropy.io import fits
@@ -328,8 +329,22 @@ def _extract_sphinx_spectra(tar_path: Path, cache_dir: Path) -> None:
             if source is None:  # pragma: no cover - guarded by member.isfile()
                 continue
             target.parent.mkdir(parents=True, exist_ok=True)
-            with source, open(target, "wb") as destination:
-                shutil.copyfileobj(source, destination)
+            temporary_path = None
+            try:
+                with source, tempfile.NamedTemporaryFile(
+                    mode="wb",
+                    dir=target.parent,
+                    prefix=f".{target.name}.",
+                    suffix=".tmp",
+                    delete=False,
+                ) as destination:
+                    temporary_path = Path(destination.name)
+                    shutil.copyfileobj(source, destination)
+                os.replace(temporary_path, target)
+            except BaseException:
+                if temporary_path is not None:
+                    temporary_path.unlink(missing_ok=True)
+                raise
 
 
 def download_sphinx_grid(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@ import os
 from pathlib import Path
 import shutil
 import pytest
-import numpy as np
 
 # Add the `src/` directory to sys.path so `speclib` is importable
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
@@ -19,12 +18,8 @@ def local_sphinx_cache(tmp_path_factory):
 
     data_dir = Path(__file__).parent / "data" / "sphinx"
     for fname in data_dir.iterdir():
-        shutil.copy(fname, cache_dir / fname.name)
-
-    # Limit the available SPHINX grid points to the provided sample files
-    utils.GRID_POINTS["sphinx"]["grid_teffs"] = np.array([3000.0])
-    utils.GRID_POINTS["sphinx"]["grid_loggs"] = np.array([4.0, 4.5])
-    utils.GRID_POINTS["sphinx"]["grid_fehs"] = np.array([0.0])
+        v4_name = fname.name.replace("_spectra.txt", ".txt")
+        shutil.copy(fname, cache_dir / v4_name)
 
     old_home = os.environ.get("HOME")
     os.environ["HOME"] = str(tmp_home)

--- a/tests/test_interpolation_toggle.py
+++ b/tests/test_interpolation_toggle.py
@@ -142,6 +142,23 @@ def test_newera_spectrum_respects_interpolate_flag(mock_newera_grid):
     assert not np.allclose(interp.flux.value, nearest.flux.value)
 
 
+def test_from_grid_preserves_positional_wavelength_argument(mock_newera_grid):
+    wavelength = np.array([985.0, 995.0]) * u.nm
+
+    spectrum = Spectrum.from_grid(
+        2300.0,
+        5.0,
+        0.0,
+        0.0,
+        wavelength,
+        model_grid="newera_jwst",
+    )
+
+    np.testing.assert_allclose(
+        spectrum.wavelength.to_value(u.nm), wavelength.to_value(u.nm)
+    )
+
+
 def test_newera_spectral_grid_respects_interpolate_flag(mock_newera_grid):
     grid = SpectralGrid(
         teff_bds=(2300.0, 2400.0),

--- a/tests/test_interpolation_toggle.py
+++ b/tests/test_interpolation_toggle.py
@@ -13,6 +13,7 @@ def spectral_grid():
         logg_bds=(4.0, 4.5),
         feh_bds=(0.0, 0.0),
         model_grid="sphinx",
+        co_ratio=0.5,
         wavelength=np.linspace(1.0, 2.0, 100) * u.micron,
     )
 
@@ -46,6 +47,7 @@ def test_binned_grid_get_spectrum_nearest_off_grid(spectral_grid):
         center=center,
         width=width,
         model_grid="sphinx",
+        co_ratio=0.5,
         wavelength=spectral_grid.wavelength,
     )
 

--- a/tests/test_sed.py
+++ b/tests/test_sed.py
@@ -2,7 +2,9 @@ from speclib import Spectrum, Filter, SED
 
 
 def test_sed_from_spectrum():
-    spec = Spectrum.from_grid(3000, 4.0, 0.0, model_grid="sphinx")
+    spec = Spectrum.from_grid(
+        3000, 4.0, 0.0, model_grid="sphinx", co_ratio=0.5
+    )
     filt = Filter("2MASS J")
     sed = SED(spec, [filt])
     assert sed.flux.unit.is_equivalent(filt.zeropoint_flux.unit)

--- a/tests/test_spectral_grid_bounds.py
+++ b/tests/test_spectral_grid_bounds.py
@@ -12,6 +12,7 @@ def test_spectral_grid_clips_bounds_to_available_grid():
             logg_bds=(3.5, 5.5),
             feh_bds=(-0.5, 0.5),
             model_grid="sphinx",
+            co_ratio=0.5,
             wavelength=np.linspace(1.0, 2.0, 10) * u.micron,
         )
 

--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -1,0 +1,184 @@
+import io
+import tarfile
+
+import astropy.units as u
+import numpy as np
+import pytest
+
+from speclib import download_sphinx_grid as public_download_sphinx_grid
+from speclib import utils
+from speclib.core import Spectrum, SpectralGrid
+
+
+def _spectrum_text(scale=1.0):
+    return (
+        "# Wavelength [um]       F [W/m2/m]\n"
+        f"1.0 {1.0 * scale}\n"
+        f"2.0 {2.0 * scale}\n"
+        f"3.0 {3.0 * scale}\n"
+    )
+
+
+def _write_spectrum(cache_dir, teff, logg, metallicity, co_ratio, scale=1.0):
+    model_dir = cache_dir / "NEWCORRECTED_CLOUDFREE"
+    model_dir.mkdir(parents=True, exist_ok=True)
+    name = (
+        f"Teff_{teff:.1f}_logg_{logg}_logZ_{metallicity:+}"
+        f"_CtoO_{co_ratio}.txt"
+    )
+    path = model_dir / name
+    path.write_text(_spectrum_text(scale))
+    return path
+
+
+def _write_test_archive(path):
+    content = _spectrum_text().encode()
+    member_name = (
+        "NEWCORRECTED_CLOUDFREE/"
+        "Teff_3000.0_logg_4.0_logZ_+0.0_CtoO_0.5.txt"
+    )
+    with tarfile.open(path, "w:gz") as archive:
+        info = tarfile.TarInfo(member_name)
+        info.size = len(content)
+        archive.addfile(info, io.BytesIO(content))
+
+        ignored = b"not a spectrum"
+        info = tarfile.TarInfo("NEWCORRECTED_CLOUDFREE/README.txt")
+        info.size = len(ignored)
+        archive.addfile(info, io.BytesIO(ignored))
+
+
+def test_download_sphinx_grid_uses_v4_metadata_and_cache(monkeypatch, tmp_path):
+    retrievals = []
+
+    def fake_retrieve(**kwargs):
+        retrievals.append(kwargs)
+        archive_path = kwargs["path"] / kwargs["fname"]
+        if not archive_path.exists():
+            _write_test_archive(archive_path)
+        return str(archive_path)
+
+    monkeypatch.setattr(utils.pooch, "retrieve", fake_retrieve)
+
+    result = utils.download_sphinx_grid(library_root=tmp_path)
+    extracted = (
+        result
+        / "NEWCORRECTED_CLOUDFREE"
+        / "Teff_3000.0_logg_4.0_logZ_+0.0_CtoO_0.5.txt"
+    )
+    assert result == tmp_path / "sphinx"
+    assert extracted.exists()
+    assert not (result / "NEWCORRECTED_CLOUDFREE" / "README.txt").exists()
+    assert retrievals[0]["url"] == utils.SPHINX_ARCHIVE_URL
+    assert retrievals[0]["fname"] == utils.SPHINX_ARCHIVE_FILENAME
+    assert retrievals[0]["known_hash"] == utils.SPHINX_ARCHIVE_HASH
+
+    extracted.write_text("cached")
+    utils.download_sphinx_grid(library_root=tmp_path)
+    assert extracted.read_text() == "cached"
+
+    stale = result / "stale.txt"
+    stale.write_text("remove me")
+    utils.download_sphinx_grid(overwrite=True, library_root=tmp_path)
+    assert not stale.exists()
+    assert extracted.read_text().startswith("# Wavelength")
+
+
+def test_download_sphinx_grid_public_alias():
+    assert public_download_sphinx_grid is utils.download_sphinx_grid
+
+
+def test_sphinx_filename_index_loading_units_and_missing_model(tmp_path):
+    cache_dir = tmp_path / "sphinx"
+    expected_path = _write_spectrum(cache_dir, 3000.0, 4.0, 0.0, 0.5)
+    _write_spectrum(cache_dir, 3000.0, 4.2, 0.0, 0.7, scale=2.0)
+    (cache_dir / "Teff_3000.0_logg_4.0_logZ_+0.0_CtoO_0.5_spectra.txt").write_text(
+        _spectrum_text()
+    )
+
+    model_list = utils.load_sphinx_model_list(library_root=tmp_path)
+    assert model_list["entries"][(3000.0, 4.0, 0.0, 0.5)] == expected_path
+    assert model_list["combinations"].shape == (2, 4)
+    np.testing.assert_array_equal(model_list["grid_co_ratios"], [0.5, 0.7])
+
+    wavelength, flux = utils.load_sphinx_spectrum(
+        3000.0, 4.0, 0.0, 0.5, library_root=tmp_path
+    )
+    assert wavelength.unit == u.micron
+    assert flux.unit == u.W / (u.m**2 * u.m)
+    np.testing.assert_allclose(wavelength.value, [1.0, 2.0, 3.0])
+    np.testing.assert_allclose(flux.value, [1.0, 2.0, 3.0])
+
+    with pytest.raises(ValueError, match="has no model"):
+        utils.load_sphinx_spectrum(
+            3000.0, 4.5, 0.0, 0.5, library_root=tmp_path
+        )
+
+
+def test_sphinx_spectrum_and_grid_select_explicit_co_slice(tmp_path):
+    cache_dir = tmp_path / "sphinx"
+    for co_ratio, scale in ((0.5, 1.0), (0.7, 2.0)):
+        _write_spectrum(cache_dir, 3000.0, 4.0, 0.0, co_ratio, scale)
+        _write_spectrum(cache_dir, 3000.0, 4.5, 0.0, co_ratio, scale * 2.0)
+
+    utils.set_library_root(tmp_path)
+    try:
+        with pytest.raises(ValueError, match="co_ratio must be specified"):
+            Spectrum.from_grid(3000.0, 4.0, 0.0, model_grid="sphinx")
+
+        spectrum = Spectrum.from_grid(
+            3000.0,
+            4.0,
+            0.0,
+            model_grid="sphinx",
+            co_ratio=0.7,
+            interpolate=False,
+        )
+        assert spectrum.wavelength.unit == u.AA
+        assert spectrum.flux.unit.is_equivalent(u.erg / (u.s * u.cm**2 * u.AA))
+
+        grid_05 = SpectralGrid(
+            (3000.0, 3000.0),
+            (4.0, 4.5),
+            (0.0, 0.0),
+            model_grid="sphinx",
+            co_ratio=0.5,
+        )
+        grid_07 = SpectralGrid(
+            (3000.0, 3000.0),
+            (4.0, 4.5),
+            (0.0, 0.0),
+            model_grid="sphinx",
+            co_ratio=0.7,
+        )
+    finally:
+        utils.set_library_root(None)
+
+    flux_05 = grid_05.get_flux(3000.0, 4.25, 0.0, interpolate=True)
+    flux_07 = grid_07.get_flux(3000.0, 4.25, 0.0, interpolate=True)
+    np.testing.assert_allclose(flux_07.value, 2.0 * flux_05.value)
+    nearest = grid_05.get_flux(3000.0, 4.25, 0.0, interpolate=False)
+    assert not np.allclose(nearest.value, flux_05.value)
+
+
+def test_sphinx_sparse_grid_interpolation_error(tmp_path):
+    cache_dir = tmp_path / "sphinx"
+    _write_spectrum(cache_dir, 3000.0, 4.0, 0.0, 0.5)
+    _write_spectrum(cache_dir, 3100.0, 4.5, 0.0, 0.5)
+
+    utils.set_library_root(tmp_path)
+    try:
+        grid = SpectralGrid(
+            (3000.0, 3100.0),
+            (4.0, 4.5),
+            (0.0, 0.0),
+            model_grid="sphinx",
+            co_ratio=0.5,
+        )
+    finally:
+        utils.set_library_root(None)
+
+    with pytest.raises(ValueError, match="lacks a required corner"):
+        grid.get_flux(3050.0, 4.25, 0.0, interpolate=True)
+    nearest = grid.get_flux(3050.0, 4.25, 0.0, interpolate=False)
+    assert nearest.shape == (3,)

--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -7,7 +7,7 @@ import pytest
 
 from speclib import download_sphinx_grid as public_download_sphinx_grid
 from speclib import utils
-from speclib.core import Spectrum, SpectralGrid
+from speclib.core import BinnedSpectralGrid, Spectrum, SpectralGrid
 
 
 def _spectrum_text(scale=1.0):
@@ -88,6 +88,34 @@ def test_download_sphinx_grid_public_alias():
     assert public_download_sphinx_grid is utils.download_sphinx_grid
 
 
+def test_sphinx_extraction_failure_does_not_leave_final_file(monkeypatch, tmp_path):
+    archive_path = tmp_path / "sphinx.tar.gz"
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    _write_test_archive(archive_path)
+    target = (
+        cache_dir
+        / "NEWCORRECTED_CLOUDFREE"
+        / "Teff_3000.0_logg_4.0_logZ_+0.0_CtoO_0.5.txt"
+    )
+    original_copyfileobj = utils.shutil.copyfileobj
+
+    def interrupted_copy(source, destination):
+        destination.write(b"partial")
+        raise OSError("interrupted extraction")
+
+    monkeypatch.setattr(utils.shutil, "copyfileobj", interrupted_copy)
+    with pytest.raises(OSError, match="interrupted extraction"):
+        utils._extract_sphinx_spectra(archive_path, cache_dir)
+
+    assert not target.exists()
+    assert list(target.parent.glob(f".{target.name}.*.tmp")) == []
+
+    monkeypatch.setattr(utils.shutil, "copyfileobj", original_copyfileobj)
+    utils._extract_sphinx_spectra(archive_path, cache_dir)
+    assert target.read_text().startswith("# Wavelength")
+
+
 def test_sphinx_filename_index_loading_units_and_missing_model(tmp_path):
     cache_dir = tmp_path / "sphinx"
     expected_path = _write_spectrum(cache_dir, 3000.0, 4.0, 0.0, 0.5)
@@ -137,6 +165,24 @@ def test_sphinx_spectrum_and_grid_select_explicit_co_slice(tmp_path):
         assert spectrum.wavelength.unit == u.AA
         assert spectrum.flux.unit.is_equivalent(u.erg / (u.s * u.cm**2 * u.AA))
 
+        canonical = Spectrum.from_grid(
+            3000.0,
+            4.0,
+            0.0,
+            model_grid="sphinx",
+            co_ratio=0.500004,
+            interpolate=False,
+        )
+        exact = Spectrum.from_grid(
+            3000.0,
+            4.0,
+            0.0,
+            model_grid="sphinx",
+            co_ratio=0.5,
+            interpolate=False,
+        )
+        np.testing.assert_allclose(canonical.flux.value, exact.flux.value)
+
         grid_05 = SpectralGrid(
             (3000.0, 3000.0),
             (4.0, 4.5),
@@ -151,6 +197,13 @@ def test_sphinx_spectrum_and_grid_select_explicit_co_slice(tmp_path):
             model_grid="sphinx",
             co_ratio=0.7,
         )
+        canonical_grid = SpectralGrid(
+            (3000.0, 3000.0),
+            (4.0, 4.5),
+            (0.0, 0.0),
+            model_grid="sphinx",
+            co_ratio=0.500004,
+        )
     finally:
         utils.set_library_root(None)
 
@@ -159,6 +212,43 @@ def test_sphinx_spectrum_and_grid_select_explicit_co_slice(tmp_path):
     np.testing.assert_allclose(flux_07.value, 2.0 * flux_05.value)
     nearest = grid_05.get_flux(3000.0, 4.25, 0.0, interpolate=False)
     assert not np.allclose(nearest.value, flux_05.value)
+    assert canonical_grid.co_ratio == 0.5
+
+
+def test_sphinx_irregular_axis_uses_true_flanking_models(tmp_path):
+    cache_dir = tmp_path / "sphinx"
+    _write_spectrum(cache_dir, 3000.0, 4.0, 0.5, 0.9, scale=1.0)
+    _write_spectrum(cache_dir, 3000.0, 4.2, 0.5, 0.9, scale=3.0)
+    _write_spectrum(cache_dir, 3000.0, 4.25, 0.5, 0.9, scale=100.0)
+
+    utils.set_library_root(tmp_path)
+    try:
+        lower = Spectrum.from_grid(
+            3000.0, 4.0, 0.5, model_grid="sphinx", co_ratio=0.9
+        )
+        upper = Spectrum.from_grid(
+            3000.0, 4.2, 0.5, model_grid="sphinx", co_ratio=0.9
+        )
+        interpolated = Spectrum.from_grid(
+            3000.0, 4.19, 0.5, model_grid="sphinx", co_ratio=0.9
+        )
+        grid = SpectralGrid(
+            (3000.0, 3000.0),
+            (4.0, 4.25),
+            (0.5, 0.5),
+            model_grid="sphinx",
+            co_ratio=0.9,
+        )
+    finally:
+        utils.set_library_root(None)
+
+    weight = (4.19 - 4.0) / (4.2 - 4.0)
+    expected = lower.flux + weight * (upper.flux - lower.flux)
+    np.testing.assert_allclose(interpolated.flux.value, expected.value)
+    np.testing.assert_allclose(
+        grid.get_flux(3000.0, 4.19, 0.5).value,
+        expected.value,
+    )
 
 
 def test_sphinx_sparse_grid_interpolation_error(tmp_path):
@@ -182,3 +272,33 @@ def test_sphinx_sparse_grid_interpolation_error(tmp_path):
         grid.get_flux(3050.0, 4.25, 0.0, interpolate=True)
     nearest = grid.get_flux(3050.0, 4.25, 0.0, interpolate=False)
     assert nearest.shape == (3,)
+
+
+def test_binned_sphinx_grid_uses_only_actual_sparse_combinations(tmp_path):
+    cache_dir = tmp_path / "sphinx"
+    _write_spectrum(cache_dir, 3000.0, 4.0, 0.0, 0.7)
+    _write_spectrum(cache_dir, 3100.0, 4.5, 0.0, 0.7, scale=2.0)
+    center = np.array([1.5, 2.5]) * u.micron
+    width = np.ones(2) * u.micron
+
+    utils.set_library_root(tmp_path)
+    try:
+        grid = BinnedSpectralGrid(
+            (3000.0, 3100.0),
+            (4.0, 4.5),
+            (0.0, 0.0),
+            center,
+            width,
+            model_grid="sphinx",
+            co_ratio=0.7,
+        )
+    finally:
+        utils.set_library_root(None)
+
+    assert grid.points.shape == (2, 3)
+    exact = grid.get_spectrum(3000.0, 4.0, 0.0)
+    nearest = grid.get_spectrum(3050.0, 4.25, 0.0, interpolate=False)
+    assert exact.shape == (2,)
+    assert nearest.shape == (2,)
+    with pytest.raises(ValueError, match="lacks a required corner"):
+        grid.get_spectrum(3050.0, 4.25, 0.0, interpolate=True)


### PR DESCRIPTION
## Summary

- Add download and cache support for the SPHINX V4 stellar atmosphere grid from Zenodo record 11392341.
- Support loading SPHINX spectra through `Spectrum.from_grid()` and `SpectralGrid`.
- Require an explicit fixed C/O slice through `co_ratio`, with interpolation and nearest-model selection within that slice.
- Index the actual available SPHINX models instead of assuming a fully rectangular grid.
- Map speclib’s existing `feh` API argument to the SPHINX filename parameter `logZ` for compatibility, without implying that the quantities are physically identical.

## Testing

- `poetry run pytest`: 71 passed
- `poetry run tox`: Python 3.11, 3.12, and 3.13 passed, 71 tests each
- `git diff --check`: clean
- Manual real-data testing with the SPHINX V4 archive succeeded:
  - exact-grid loading at 3000 K and 3100 K
  - interpolation at 3050 K with `logg=5.0`, `logZ=0.0`, C/O 0.5
  - irregular-grid interpolation at `Teff=3000 K`, `logg=4.19`, `logZ=+0.5`, C/O 0.9
  - `Spectrum.from_grid()` and `SpectralGrid` agree for both interpolation cases
- Additional manual regression smoke tests passed for positional compatibility, C/O canonicalization, and sparse `BinnedSpectralGrid` behavior

Closes #50