### PR TITLE
Add first-class MPS-ATLAS model support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added first-class MPS-ATLAS Set 1 and Set 2 support, with `mps-atlas`
+  aliasing Set 1, plus automatic archive downloads and caching.
+- Added exact, nearest, and interpolated MPS-ATLAS retrieval through the
+  standard `Spectrum` and `SpectralGrid` APIs.
+- Added MPS-ATLAS wavelength-axis normalization that preserves wavelength-flux
+  pairing while ensuring strictly increasing spectral coordinates.
 - Added wavelength-dependent Gaussian resolving-power support for `Spectrum`
   and `SpectralGrid` with `set_variable_resolving_power()`.
 - Added support for loading the SPHINX V4 stellar atmosphere grid from Zenodo
@@ -18,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- Added MPS-ATLAS model-library documentation covering Set 1 and Set 2,
+  caching, interpolation behavior, citations, and scientific limitations.
 - Expanded the Read the Docs site with task-based navigation, installation and
   Quickstart guides, model-library references, a generated API reference, and
   integrated citation, changelog, and contributing information.

--- a/README.md
+++ b/README.md
@@ -72,12 +72,12 @@ Downloaded spectral libraries are stored in `~/.speclib/libraries` by default.
 Set the `SPECLIB_LIBRARY_PATH` environment variable or call
 `speclib.utils.set_library_root("/path/to/cache")` to use a different location.
 
-Download, extraction, storage, and interpolation behavior for PHOENIX, SPHINX,
-and NewEra are documented in the
+Download, extraction, storage, and interpolation behavior for PHOENIX,
+MPS-ATLAS, SPHINX, and NewEra are documented in the
 [model library reference](https://speclib.readthedocs.io/en/latest/models/index.html).
 
 ---
 
 ## License
 
-MIT © 2025 Benjamin V. Rackham
+MIT © 2021–2026 Benjamin V. Rackham

--- a/docs/api/utilities.rst
+++ b/docs/api/utilities.rst
@@ -10,6 +10,8 @@ Package-level download helpers
 
 .. autofunction:: download_sphinx_grid
 
+.. autofunction:: download_mps_atlas_grid
+
 .. autofunction:: download_newera_grid
 
 .. autofunction:: download_file

--- a/docs/citation.rst
+++ b/docs/citation.rst
@@ -26,6 +26,11 @@ Also cite the data product underlying your result:
   <https://doi.org/10.5281/zenodo.11392341>`_ and `Iyer et al. (2023)
   <https://doi.org/10.3847/1538-4357/acabc2>`_, as requested by the data
   record.
+* MPS-ATLAS: `Kostogryz et al. (2023)
+  <https://doi.org/10.3847/2515-5172/acc180>`_, the `Edmond v3 data release
+  <https://doi.org/10.17617/3.NJ56TR>`_, `Witzke et al. (2021)
+  <https://doi.org/10.1051/0004-6361/202140275>`_, and `Kostogryz et al.
+  (2022) <https://doi.org/10.1051/0004-6361/202243722>`_.
 * PHOENIX/1D NewEra: `Hauschildt et al. (2025)
   <https://doi.org/10.1051/0004-6361/202554171>`_ and the `V3.4 FDR release
   <https://doi.org/10.25592/uhhfdm.17935>`_.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,8 +4,9 @@ speclib documentation
 ``speclib`` provides tools for loading, interpolating, resampling,
 binning, broadening, and synthesizing photometry from stellar model spectra.
 It currently supports PHOENIX ACES (`Husser et al. 2013
-<https://doi.org/10.1051/0004-6361/201219058>`_), SPHINX (`Iyer et al. 2023
-<https://doi.org/10.3847/1538-4357/acabc2>`_), and PHOENIX/1D NewEra spectra
+<https://doi.org/10.1051/0004-6361/201219058>`_), MPS-ATLAS (`Kostogryz et
+al. 2023 <https://doi.org/10.3847/2515-5172/acc180>`_), SPHINX (`Iyer et al.
+2023 <https://doi.org/10.3847/1538-4357/acabc2>`_), and PHOENIX/1D NewEra spectra
 (`Hauschildt et al. 2025
 <https://doi.org/10.1051/0004-6361/202554171>`_).
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -53,6 +53,9 @@ Data implications differ by model family:
   and can require substantial time and storage.
 * :func:`~speclib.download_sphinx_grid` downloads a checksummed, approximately
   161 MB V4 archive, retains it, and extracts the spectrum text files.
+* :func:`~speclib.download_mps_atlas_grid` downloads one checksummed v3 archive
+  of about 9.5 GB into ``mps-atlas/set1`` or ``mps-atlas/set2``. The archive is
+  retained and requested disk-integrated members are read directly from it.
 * :func:`~speclib.download_newera_grid` caches one reduced-resolution archive
   (about 845 MB to 18.2 GB, depending on flavor). It does not extract the
   archive by default; loaders extract a requested metallicity file on demand.

--- a/docs/models/index.rst
+++ b/docs/models/index.rst
@@ -10,6 +10,7 @@ before selecting a ``model_grid`` value.
    :maxdepth: 1
 
    phoenix
+   mps_atlas
    sphinx
    newera
 
@@ -19,6 +20,9 @@ Quick selection
 * Use :doc:`phoenix` for the established PHOENIX-ACES-AGSS-COND-2011
   high-resolution stellar library, with individual FITS files downloaded as
   needed.
+* Use :doc:`mps_atlas` for a dense FGK grid and broad SED work on 1221
+  nonuniform ODF intervals; choose its abundance/mixing-length Set 1 or Set 2
+  explicitly when that distinction matters.
 * Use :doc:`sphinx` for the low-resolution M-dwarf grid with an explicit C/O
   dimension and a comparatively small single archive.
 * Use :doc:`newera` for the newer PHOENIX/1D LTE atmospheres and choose its

--- a/docs/models/mps_atlas.rst
+++ b/docs/models/mps_atlas.rst
@@ -1,0 +1,181 @@
+MPS-ATLAS
+=========
+
+Product and scope
+-----------------
+
+``speclib`` supports the disk-integrated spectra in release v3 of the
+`MPS-ATLAS Library of Stellar Model Atmospheres and Spectra
+<https://doi.org/10.17617/3.NJ56TR>`_. The library is described by
+`Kostogryz et al. (2023) <https://doi.org/10.3847/2515-5172/acc180>`_ and was
+computed with the code presented by `Witzke et al. (2021)
+<https://doi.org/10.1051/0004-6361/202140275>`_. The atmosphere and
+limb-darkening grid is described by `Kostogryz et al. (2022)
+<https://doi.org/10.1051/0004-6361/202243722>`_.
+
+This is a 1D LTE opacity-distribution-function (ODF) product intended for
+stellar SEDs, broadband and spectrophotometric calculations, and
+transit-adjacent applications that do not require resolved spectral lines.
+Only ``mpsa_flux_spectra.dat``, the disk-integrated product, is exposed by the
+current API. The upstream atmosphere structures and 24-position
+center-to-limb intensities are not loaded.
+
+Two discrete sets
+-----------------
+
+Set 1 and Set 2 are different scientific flavors. A spectrum or
+:class:`~speclib.SpectralGrid` always fixes one set before exact lookup,
+nearest selection, or interpolation; the sets are never blended.
+
+.. list-table:: MPS-ATLAS selectors
+   :header-rows: 1
+   :widths: 22 29 29 20
+
+   * - Selector
+     - Abundance mixture
+     - Mixing-length treatment
+     - v3 archive
+   * - ``mps-atlas-set1``
+     - Grevesse & Sauval (1998)
+     - fixed :math:`\alpha_\mathrm{MLT}=1.25`
+     - ``set1.zip``; 9,503,312,271 bytes
+   * - ``mps-atlas-set2``
+     - Asplund et al. (2009)
+     - parameter-dependent values from Viani et al. (2018)
+     - ``set2.zip``; 9,430,754,401 bytes
+   * - ``mps-atlas``
+     - Set 1
+     - Set 1
+     - alias of ``mps-atlas-set1``
+
+The generic alias preserves the meaning of the former single-set
+compatibility path and provides a convenient default. It does not imply that
+Set 1 is scientifically preferable for every application. Loaded objects
+record the canonical selector (``mps-atlas-set1`` or ``mps-atlas-set2``) and
+the corresponding ``model_set`` value.
+
+Parameter and wavelength grids
+------------------------------
+
+Both released sets declare 34,160 nominal combinations on these axes:
+
+* :math:`T_\mathrm{eff}` = 3500--9000 K in 100 K steps;
+* :math:`\log g` = 3.0, 3.5, 4.0, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, and 5.0
+  (cgs);
+* [M/H] = -5.0--+1.5 across 61 values, with especially fine 0.05 dex
+  sampling from -1.0 through +0.5.
+
+The historical ``feh`` argument to :meth:`speclib.Spectrum.from_grid` selects
+the upstream **[M/H]** coordinate for this family. Each archive is indexed
+independently from its actual member names, so a nominal axis value is not
+treated as proof that a particular combination exists.
+
+Every spectrum contains 1221 nonuniform Kurucz ODF intervals from about
+9.09 nm to 160,000 nm (160 micrometers). Across much of the optical and
+infrared the local interval spacing is roughly
+:math:`\lambda/\Delta\lambda \sim 250`, and it is lower in parts of the UV.
+That ratio characterizes tabulation, not a measured or Gaussian resolving
+power. The terminal infrared intervals are very coarse, and the enormous
+nominal wavelength span should not be interpreted as uniform information
+content or sensitivity. Use PHOENIX or an appropriate NewEra product when
+line-resolved or substantially higher-sampling spectra are required.
+
+The v3 flux files share a mostly ascending ODF coordinate sequence with one
+local reversal near 91 nm. During loading, ``speclib`` stably sorts wavelength
+and flux together into ascending order before interpolation or construction of
+a :class:`~speclib.Spectrum`. Exact repeated coordinates, if encountered, are
+collapsed only when their paired flux values agree to tight numerical
+precision; conflicting duplicates raise ``ValueError``. Merely close
+wavelengths remain distinct.
+
+Units and physical conversion
+-----------------------------
+
+Source files tabulate wavelength in nm and disk-integrated
+:math:`F_\nu` in ``erg s-1 cm-2 Hz-1`` using the release's irradiance
+convention at 1 AU for a solar-radius source. ``speclib`` first applies the
+documented geometric factor :math:`(\mathrm{AU}/R_\odot)^2`, then uses
+Astropy's spectral-density equivalency to convert to surface
+:math:`F_\lambda`. Returned spectra have ascending wavelengths in Å and flux
+density in ``erg / (s cm2 Å)``, matching the package convention.
+
+Download and cache behavior
+---------------------------
+
+Edmond distributes whole-set archives rather than individual stellar models.
+The first request for a set therefore downloads about 9.5 GB. Check available
+space and choose the library root before loading:
+
+.. code-block:: python
+
+   from speclib import download_mps_atlas_grid
+   from speclib.utils import set_library_root
+
+   set_library_root("/data/stellar-models")
+   download_mps_atlas_grid("set2")
+
+The helper resolves the archive through the DOI-backed Edmond dataset API,
+checks release metadata against the v3 size and published MD5, and lets pooch
+verify the download. The cache layout is:
+
+.. code-block:: text
+
+   <library root>/mps-atlas/set1/set1.zip
+   <library root>/mps-atlas/set2/set2.zip
+
+The selected ZIP is retained and indexed separately. Requested flux members
+are read directly from it; atmosphere and intensity members are not extracted.
+Repeated requests reuse the archive and in-process index. Passing
+``overwrite=True`` clears and refreshes only the selected set. A corrupt
+cached archive is removed with an actionable error. Old manually arranged
+files directly under ``mps-atlas`` are not silently interpreted as Set 1;
+move to the new set-specific cache through the downloader.
+
+Retrieval examples
+------------------
+
+High-level loading triggers the same acquisition automatically:
+
+.. code-block:: python
+
+   from speclib import Spectrum, SpectralGrid
+
+   default_set1 = Spectrum.from_grid(
+       5800, 4.5, 0.0, model_grid="mps-atlas"
+   )
+   explicit_set1 = Spectrum.from_grid(
+       5800, 4.5, 0.0, model_grid="mps-atlas-set1"
+   )
+   set2 = Spectrum.from_grid(
+       5800, 4.5, 0.0, model_grid="mps-atlas-set2"
+   )
+
+   grid = SpectralGrid(
+       teff_bds=(5700, 5900),
+       logg_bds=(4.4, 4.6),
+       feh_bds=(-0.05, 0.05),
+       model_grid="mps-atlas-set2",
+   )
+
+An exact request returns its archive member. With ``interpolate=False``, an
+off-grid request selects the nearest actual combination in the selected set,
+with distances scaled by the typical step of each axis. With
+``interpolate=True``, interpolation is trilinear in Teff, log g, and [M/H]
+only. All required corners must exist in that same set and share an identical
+wavelength axis; otherwise loading raises ``ValueError``. Requests beyond the
+selected archive's parameter range also raise ``ValueError`` rather than
+extrapolating.
+
+Center-to-limb data
+-------------------
+
+The v3 archives also contain ``mpsa_intensity_spectra.dat`` at 24 positions
+from :math:`\mu=1.0` to 0.01. These specific intensities are valuable for
+limb-darkening and stellar-disk calculations, but :math:`\mu` does not fit the
+current three-parameter :class:`~speclib.SpectralGrid` model. They remain out
+of scope pending a dedicated public API; loading disk-integrated spectra does
+not extract or integrate them.
+
+For publication, cite Kostogryz et al. (2023), the Edmond data release,
+Witzke et al. (2021), and Kostogryz et al. (2022), in addition to
+:doc:`../citation` for ``speclib``.

--- a/docs/user_guide/interpolation.rst
+++ b/docs/user_guide/interpolation.rst
@@ -3,8 +3,9 @@ Interpolation and boundaries
 
 Interpolation is linear at each wavelength in the three axes
 :math:`T_\mathrm{eff}`, :math:`\log g`, and metallicity. It assumes that the
-corner spectra share a wavelength axis. C/O (SPHINX) and alpha enhancement
-(NewEra) select a fixed slice and are not interpolated.
+corner spectra share a wavelength axis. C/O (SPHINX), alpha enhancement
+(NewEra), and the selected MPS-ATLAS set identify fixed slices or flavors and
+are not interpolated.
 
 Exact, nearest, and interpolated requests
 -----------------------------------------
@@ -18,8 +19,9 @@ request:
   interpolation.
 
 For regular axes such as those used by PHOENIX, nearest selection is performed
-independently on each of the three coordinates. SPHINX chooses the nearest *actual*
-combination after scaling each axis by its typical grid step. Ties follow
+independently on each of the three coordinates. SPHINX and MPS-ATLAS choose
+the nearest *actual* combination after scaling each axis by its typical grid
+step. MPS-ATLAS searches only the selected set's archive index. Ties follow
 NumPy's first minimum and should not be treated as a scientific model
 selection rule.
 
@@ -27,7 +29,8 @@ Incomplete grids
 ----------------
 
 PHOENIX has missing models at some combinations; NewEra explicitly excludes physically
-unavailable static models; SPHINX V4 is indexed from exact filenames.
+unavailable static models; SPHINX V4 and each MPS-ATLAS set are indexed from
+exact filenames.
 
 For SPHINX, interpolation that needs a missing corner raises ``ValueError``
 and explains which corner is missing. Use nearest retrieval or choose another
@@ -36,7 +39,9 @@ point; ``speclib`` does not fill that hole. For the reduced NewEra selectors,
 the prebuilt nearest-neighbor interpolator. Consequently,
 ``interpolate=True`` can produce a nearest spectrum rather than a linearly
 interpolated spectrum in a sparse region. The fallback is not used for
-SPHINX. Other regular selectors propagate a missing key error.
+SPHINX. MPS-ATLAS likewise raises ``ValueError`` for a missing corner or
+incompatible corner wavelength grid and never consults the other set. Other
+regular selectors propagate a missing key error.
 
 Bounds and extrapolation
 ------------------------
@@ -47,7 +52,9 @@ off-grid interior bounds are silently expanded to bracket the request. A
 retrieval outside the resulting ``teff_bds``, ``logg_bds``, or ``feh_bds``
 raises ``ValueError``. No grid retrieval extrapolates beyond loaded bounds.
 
-``Spectrum.from_grid`` does not run the constructor clipping step. A value
-outside an axis eventually fails while finding bounds or loading a file.
+``Spectrum.from_grid`` does not run the constructor clipping step. MPS-ATLAS
+explicitly rejects a value beyond the selected set's indexed axes; for other
+families, a value outside an axis eventually fails while finding bounds or
+loading a file.
 Validate requested coordinates against the appropriate model page and, for an
 incomplete library, against the actual available combinations.

--- a/docs/user_guide/model_libraries.rst
+++ b/docs/user_guide/model_libraries.rst
@@ -1,10 +1,10 @@
 Model library workflows
 =======================
 
-The primary documented families are PHOENIX, SPHINX, and PHOENIX/1D NewEra.
-They do not have identical grids, units on disk, completeness, or download
-behavior. Use the dedicated :doc:`../models/index` pages to choose a product
-and cite it.
+The primary documented families are PHOENIX, MPS-ATLAS, SPHINX, and
+PHOENIX/1D NewEra. They do not have identical grids, units on disk,
+completeness, or download behavior. Use the dedicated
+:doc:`../models/index` pages to choose a product and cite it.
 
 The common loading interface is:
 
@@ -24,16 +24,17 @@ The three numeric coordinates are effective temperature in kelvin, base-10
 surface gravity in cgs, and the library's metallicity coordinate. For SPHINX,
 ``feh`` selects the filename field called ``logZ`` and ``co_ratio`` is required.
 For NewEra, ``feh`` selects the grid's [M/H]-like ``Z`` field and ``alpha`` is
-an additional fixed selection. ``speclib`` does not interpolate C/O or alpha.
+an additional fixed selection. For MPS-ATLAS, ``feh`` selects [M/H], while
+``mps-atlas-set1`` and ``mps-atlas-set2`` fix different abundance and
+mixing-length assumptions, with ``mps-atlas`` defaulting to Set 1.
+``speclib`` does not interpolate C/O, alpha, or between distinct model-library
+families or flavors (for example, MPS-ATLAS Set 1 and Set 2).
 
 Additional accepted selectors
 -----------------------------
 
-``Spectrum.from_grid`` also accepts ``drift-phoenix``, ``mps-atlas``, and
-``nextgen-solar``. These are compatibility paths that require the user to
-place files in the expected cache layout; there is no corresponding public
-download helper. ``newera`` selects individual high-sampling-rate HDF5 files,
-whereas ``newera_gaia``, ``newera_jwst``, and ``newera_lowres`` select the
-reduced archives described on :doc:`../models/newera`. These compatibility
-selectors are intentionally not presented as equally supported top-level
-families.
+``Spectrum.from_grid`` also accepts ``drift-phoenix`` and ``nextgen-solar`` as
+compatibility paths that require users to arrange their caches. ``newera``
+selects individual high-sampling-rate HDF5 files, whereas ``newera_gaia``,
+``newera_jwst``, and ``newera_lowres`` select the reduced archives described
+on :doc:`../models/newera`.

--- a/src/speclib/__init__.py
+++ b/src/speclib/__init__.py
@@ -19,6 +19,7 @@ from .core import Spectrum, BinnedSpectrum, SpectralGrid, BinnedSpectralGrid
 from .photometry import Filter, SED, SEDGrid, apply_filter, mag_to_flux
 from .utils import (
     download_file,
+    download_mps_atlas_grid,
     download_newera_grid,
     download_phoenix_grid,
     download_sphinx_grid,
@@ -36,6 +37,7 @@ __all__ = [
     "mag_to_flux",
     "download_file",
     "download_phoenix_grid",
+    "download_mps_atlas_grid",
     "download_newera_grid",
     "download_sphinx_grid",
 ]

--- a/src/speclib/core.py
+++ b/src/speclib/core.py
@@ -59,8 +59,8 @@ def _sphinx_grid_slice(co_ratio):
     return grid_points, combinations, canonical_co_ratio
 
 
-def _sphinx_flanking_values(grid, value):
-    """Return the true lower and upper SPHINX grid values around a query."""
+def _flanking_values(grid, value):
+    """Return the true lower and upper grid values around a query."""
 
     grid = np.asarray(grid)
     lower = grid[grid <= value].max() if np.any(grid <= value) else grid.min()
@@ -68,8 +68,8 @@ def _sphinx_flanking_values(grid, value):
     return np.array([lower, upper])
 
 
-def _nearest_sphinx_index(points, requested):
-    """Return the nearest actual SPHINX combination in grid-step units."""
+def _nearest_available_index(points, requested):
+    """Return the nearest actual grid combination in grid-step units."""
 
     scales = []
     for axis in range(3):
@@ -80,6 +80,36 @@ def _nearest_sphinx_index(points, requested):
         axis=1,
     )
     return int(np.argmin(distances))
+
+
+def _mps_atlas_grid_slice(model_set):
+    """Return grid axes and exact combinations for one MPS-ATLAS set."""
+
+    model_list = utils.load_mps_atlas_model_list(model_set)
+    grid_points = {
+        "grid_teffs": model_list["grid_teffs"],
+        "grid_loggs": model_list["grid_loggs"],
+        "grid_fehs": model_list["grid_fehs"],
+    }
+    return grid_points, model_list["combinations"]
+
+
+def _validate_mps_atlas_ranges(teff, logg, metallicity, grid_points, model_set):
+    """Reject coordinates outside one MPS-ATLAS set's available axes."""
+
+    coordinates = (teff, logg, metallicity)
+    axis_names = ("Teff", "logg", "[M/H]")
+    axes = (
+        grid_points["grid_teffs"],
+        grid_points["grid_loggs"],
+        grid_points["grid_fehs"],
+    )
+    for name, value, axis in zip(axis_names, coordinates, axes):
+        if value < np.min(axis) or value > np.max(axis):
+            raise ValueError(
+                f"MPS-ATLAS {model_set} {name}={value} is outside the "
+                f"available range [{np.min(axis)}, {np.max(axis)}]."
+            )
 
 
 def _validate_delta_lambda(delta_lambda):
@@ -739,7 +769,7 @@ class Spectrum(Spectrum1D):
 
         feh : float
             [Fe/H] of the model. For SPHINX this selects the filename's
-            ``logZ`` metallicity parameter.
+            ``logZ`` metallicity parameter; for MPS-ATLAS it is [M/H].
 
         alpha : float, optional
             Alpha enhancement for NewEra models. This selects a fixed model
@@ -775,20 +805,41 @@ class Spectrum(Spectrum1D):
             A spectrum for the specified parameters.
         """
         # First check that the model_grid is valid.
-        self.model_grid = model_grid.lower()
-        if self.model_grid not in utils.VALID_MODELS:
+        requested_model_grid = model_grid.lower()
+        if requested_model_grid not in utils.VALID_MODELS:
             raise NotImplementedError(
-                f'"{self.model_grid}" model grid not found. '
+                f'"{requested_model_grid}" model grid not found. '
                 + "Currently supported models are: "
                 + str(utils.VALID_MODELS)
             )
+        mps_atlas_set = None
+        if requested_model_grid in utils.MPS_ATLAS_SELECTORS:
+            mps_atlas_set = utils.normalize_mps_atlas_set(requested_model_grid)
+            self.model_grid = utils.canonical_mps_atlas_selector(mps_atlas_set)
+        else:
+            self.model_grid = requested_model_grid
 
         # Define grid points. SPHINX is sparse, so derive the selected C/O slice
         # from the exact filenames in the extracted V4 archive.
         sphinx_combinations = None
+        mps_atlas_combinations = None
         if self.model_grid == "sphinx":
             self.grid_points, sphinx_combinations, co_ratio = _sphinx_grid_slice(
                 co_ratio
+            )
+        elif mps_atlas_set is not None:
+            _validate_mps_atlas_ranges(
+                teff,
+                logg,
+                feh,
+                utils.GRID_POINTS[self.model_grid],
+                mps_atlas_set,
+            )
+            self.grid_points, mps_atlas_combinations = _mps_atlas_grid_slice(
+                mps_atlas_set
+            )
+            _validate_mps_atlas_ranges(
+                teff, logg, feh, self.grid_points, mps_atlas_set
             )
         else:
             self.grid_points = utils.GRID_POINTS[self.model_grid]
@@ -1112,7 +1163,7 @@ class Spectrum(Spectrum1D):
                 np.all(np.isclose(exact_combinations, requested), axis=1)
             )
             if not model_in_grid and not interpolate:
-                nearest_index = _nearest_sphinx_index(
+                nearest_index = _nearest_available_index(
                     exact_combinations, requested
                 )
                 teff, logg, feh = exact_combinations[nearest_index]
@@ -1121,15 +1172,15 @@ class Spectrum(Spectrum1D):
                 if teff_in_grid:
                     teff_bds = [teff, teff]
                 else:
-                    teff_bds = _sphinx_flanking_values(self.grid_teffs, teff)
+                    teff_bds = _flanking_values(self.grid_teffs, teff)
                 if logg_in_grid:
                     logg_bds = [logg, logg]
                 else:
-                    logg_bds = _sphinx_flanking_values(self.grid_loggs, logg)
+                    logg_bds = _flanking_values(self.grid_loggs, logg)
                 if feh_in_grid:
                     feh_bds = [feh, feh]
                 else:
-                    feh_bds = _sphinx_flanking_values(self.grid_fehs, feh)
+                    feh_bds = _flanking_values(self.grid_fehs, feh)
 
                 flux_dict = {}
                 wave_lib = None
@@ -1155,66 +1206,80 @@ class Spectrum(Spectrum1D):
             elif model_in_grid:
                 wave_lib, flux = load_wave_flux(teff, logg, feh)
 
-        elif self.model_grid == "mps-atlas":
-            # Only works if the user has already cached the MPS-Atlas model grid
-            lib_wave_unit = u.nm
-            lib_flux_unit = (
-                u.Unit("erg / (s * cm^2 * Hz^1)") * (u.AU / u.R_sun).cgs ** 2
-            )
-            cache_dir = utils.get_library_root() / "mps-atlas"
-            cache_dir.mkdir(parents=True, exist_ok=True)
-            fname_str = "MH{:+0.2f}/teff{:4.0f}/logg{:0.1f}/mpsa_flux_spectra.dat"
+        elif mps_atlas_set is not None:
+            lib_wave_unit = u.AA
+            lib_flux_unit = u.erg / (u.s * u.cm**2 * u.AA)
 
-            # Load the wavelength array
-            wave_local_path = (
-                cache_dir / "MH+0.00/teff3500/logg3.0/mpsa_flux_spectra.dat"
-            )
-            wave_lib = np.loadtxt(wave_local_path, unpack=True, usecols=0)
-
-            teff_in_grid = teff in self.grid_teffs
-            logg_in_grid = logg in self.grid_loggs
-            feh_in_grid = feh in self.grid_fehs
-            model_in_grid = all([teff_in_grid, logg_in_grid, feh_in_grid])
-            if not model_in_grid:
-                if teff_in_grid:
-                    teff_bds = [teff, teff]
-                else:
-                    teff_bds = utils.find_bounds(self.grid_teffs, teff)
-                if logg_in_grid:
-                    logg_bds = [logg, logg]
-                else:
-                    logg_bds = utils.find_bounds(self.grid_loggs, logg)
-                if feh_in_grid:
-                    feh_bds = [feh, feh]
-                else:
-                    feh_bds = utils.find_bounds(self.grid_fehs, feh)
-
-                flux_dict = {}
-                for tt in teff_bds:
-                    flux_dict[tt] = {}
-                    for gg in logg_bds:
-                        flux_dict[tt][gg] = {}
-                        for ff in feh_bds:
-                            fname = fname_str.format(ff, tt, gg)
-                            flux_dict[tt][gg][ff] = np.loadtxt(
-                                cache_dir / fname, unpack=True, usecols=1
-                            )
-
-                flux = utils.trilinear_interpolate(
-                    flux_dict, (teff_bds, logg_bds, feh_bds), (teff, logg, feh)
+            def load_wave_flux(teff_, logg_, metallicity_):
+                wavelength_, flux_ = utils.load_mps_atlas_spectrum(
+                    teff_, logg_, metallicity_, mps_atlas_set
+                )
+                return (
+                    wavelength_.to_value(lib_wave_unit),
+                    flux_.to_value(lib_flux_unit),
                 )
 
-            elif model_in_grid:
-                # Load the flux array
-                fname = fname_str.format(feh, teff, logg)
-                flux = np.loadtxt(cache_dir / fname, unpack=True, usecols=1)
+            requested = np.array([teff, logg, feh], dtype=float)
+            exact_combinations = mps_atlas_combinations[:, :3]
+            model_in_grid = np.any(
+                np.all(
+                    np.isclose(
+                        exact_combinations, requested, rtol=0.0, atol=1e-8
+                    ),
+                    axis=1,
+                )
+            )
+            if not model_in_grid and not interpolate:
+                nearest_index = _nearest_available_index(
+                    exact_combinations, requested
+                )
+                teff, logg, feh = exact_combinations[nearest_index]
+                model_in_grid = True
+
+            if model_in_grid:
+                wave_lib, flux = load_wave_flux(teff, logg, feh)
+            else:
+                teff_bds = _flanking_values(self.grid_teffs, teff)
+                logg_bds = _flanking_values(self.grid_loggs, logg)
+                feh_bds = _flanking_values(self.grid_fehs, feh)
+
+                flux_dict = {}
+                wave_lib = None
+                try:
+                    for tt in teff_bds:
+                        flux_dict[tt] = {}
+                        for gg in logg_bds:
+                            flux_dict[tt][gg] = {}
+                            for ff in feh_bds:
+                                wavelength_, flux_ = load_wave_flux(tt, gg, ff)
+                                if wave_lib is None:
+                                    wave_lib = wavelength_
+                                elif not np.array_equal(wave_lib, wavelength_):
+                                    raise ValueError(
+                                        "MPS-ATLAS spectra required for "
+                                        "interpolation do not share a wavelength "
+                                        "grid."
+                                    )
+                                flux_dict[tt][gg][ff] = flux_
+                except ValueError as exc:
+                    raise ValueError(
+                        f"Cannot interpolate this MPS-ATLAS {mps_atlas_set} "
+                        "point because the selected set lacks a required "
+                        f"corner model: {exc}"
+                    ) from exc
+
+                flux = utils.trilinear_interpolate(
+                    flux_dict,
+                    (teff_bds, logg_bds, feh_bds),
+                    (teff, logg, feh),
+                )
 
         # Load `~speclib.Spectrum` object
         spec = Spectrum(
             spectral_axis=wave_lib * lib_wave_unit,
             flux=flux * lib_flux_unit,
         )
-        # Ensure spectra are ordered correctly (problem for mps-atlas grid)
+        # Ensure spectra are ordered correctly.
         idx_order = np.argsort(spec.wavelength)
         spec = Spectrum(
             spectral_axis=spec.wavelength[idx_order], flux=spec.flux[idx_order]
@@ -1239,6 +1304,10 @@ class Spectrum(Spectrum1D):
         # Resample the spectrum to the desired wavelength array
         if wavelength is not None:
             spec = spec.resample(wavelength)
+
+        spec.model_grid = self.model_grid
+        if mps_atlas_set is not None:
+            spec.model_set = mps_atlas_set
 
         return spec
 
@@ -1691,17 +1760,28 @@ class SpectralGrid(object):
             _validate_resolving_power(spectral_resolving_power)
 
         # First check that the model_grid is valid.
-        self.model_grid = model_grid.lower()
-        if self.model_grid not in utils.VALID_MODELS:
+        requested_model_grid = model_grid.lower()
+        if requested_model_grid not in utils.VALID_MODELS:
             raise NotImplementedError(
-                f'"{self.model_grid}" model grid not found. '
+                f'"{requested_model_grid}" model grid not found. '
                 + "Currently supported models are: "
                 + str(utils.VALID_MODELS)
             )
 
         self.co_ratio = co_ratio
+        self.model_set = None
+        mps_atlas_combinations = None
+        if requested_model_grid in utils.MPS_ATLAS_SELECTORS:
+            self.model_set = utils.normalize_mps_atlas_set(requested_model_grid)
+            self.model_grid = utils.canonical_mps_atlas_selector(self.model_set)
+        else:
+            self.model_grid = requested_model_grid
         if self.model_grid == "sphinx":
             self.grid_points, _, self.co_ratio = _sphinx_grid_slice(co_ratio)
+        elif self.model_set is not None:
+            self.grid_points, mps_atlas_combinations = _mps_atlas_grid_slice(
+                self.model_set
+            )
         else:
             self.grid_points = utils.GRID_POINTS[self.model_grid]
         self.grid_teffs = self.grid_points["grid_teffs"]
@@ -1737,30 +1817,49 @@ class SpectralGrid(object):
         spectrum_kwargs = dict(kwargs)
         if self.model_grid == "sphinx":
             spectrum_kwargs["co_ratio"] = self.co_ratio
-        for teff in self.teffs:
-            fluxes[teff] = {}
-            for logg in self.loggs:
-                fluxes[teff][logg] = {}
-                for feh in self.fehs:
-                    try:
-                        spec = Spectrum.from_grid(
-                            teff,
-                            logg,
-                            feh,
-                            model_grid=self.model_grid,
-                            **spectrum_kwargs,
-                        )
-                    except ValueError:
-                        # Skip combinations that do not exist in sparse grids
-                        continue
+        if mps_atlas_combinations is not None:
+            within_bounds = (
+                (mps_atlas_combinations[:, 0] >= self.teff_bds[0])
+                & (mps_atlas_combinations[:, 0] <= self.teff_bds[1])
+                & (mps_atlas_combinations[:, 1] >= self.logg_bds[0])
+                & (mps_atlas_combinations[:, 1] <= self.logg_bds[1])
+                & (mps_atlas_combinations[:, 2] >= self.feh_bds[0])
+                & (mps_atlas_combinations[:, 2] <= self.feh_bds[1])
+            )
+            parameter_combinations = mps_atlas_combinations[within_bounds, :3]
+        else:
+            parameter_combinations = np.array(
+                [
+                    (teff, logg, feh)
+                    for teff in self.teffs
+                    for logg in self.loggs
+                    for feh in self.fehs
+                ]
+            )
 
-                    # Resample the spectrum to the desired wavelength array
-                    if wavelength is not None:
-                        spec = spec.resample(wavelength)
+        for teff, logg, feh in parameter_combinations:
+            fluxes.setdefault(teff, {}).setdefault(logg, {})
+            try:
+                spec = Spectrum.from_grid(
+                    teff,
+                    logg,
+                    feh,
+                    model_grid=self.model_grid,
+                    **spectrum_kwargs,
+                )
+            except ValueError:
+                if self.model_set is not None:
+                    raise
+                # Skip combinations that do not exist in sparse grids.
+                continue
 
-                    fluxes[teff][logg][feh] = spec.flux
-                    points.append([teff, logg, feh])
-                    data.append(spec.flux.value)
+            # Resample the spectrum to the desired wavelength array
+            if wavelength is not None:
+                spec = spec.resample(wavelength)
+
+            fluxes[teff][logg][feh] = spec.flux
+            points.append([teff, logg, feh])
+            data.append(spec.flux.value)
 
         self.fluxes = fluxes
 
@@ -1985,13 +2084,19 @@ class SpectralGrid(object):
             "newera_jwst",
             "newera_lowres",
             "sphinx",
+            "mps-atlas-set1",
+            "mps-atlas-set2",
         ]:
             if self.interpolator is None or not self.points.size:
                 raise ValueError("SpectralGrid contains no spectra")
 
             if not interpolate:
-                if self.model_grid == "sphinx":
-                    nearest_index = _nearest_sphinx_index(
+                if self.model_grid in {
+                    "sphinx",
+                    "mps-atlas-set1",
+                    "mps-atlas-set2",
+                }:
+                    nearest_index = _nearest_available_index(
                         self.points, (teff, logg, feh)
                     )
                     flux = self.data[nearest_index]
@@ -2009,6 +2114,12 @@ class SpectralGrid(object):
                         raise ValueError(
                             "Cannot interpolate this SPHINX point because the "
                             "selected C/O slice lacks a required corner model."
+                        ) from None
+                    if self.model_set is not None:
+                        raise ValueError(
+                            f"Cannot interpolate this MPS-ATLAS {self.model_set} "
+                            "point because the selected set lacks a required "
+                            "corner model."
                         ) from None
                     # Fall back to nearest-neighbour evaluation for sparse grids
                     flux = self.interpolator((teff, logg, feh))
@@ -2126,16 +2237,23 @@ class BinnedSpectralGrid(object):
             model family.
         """
         # First check that the model_grid is valid.
-        self.model_grid = model_grid.lower()
-        if self.model_grid not in utils.VALID_MODELS:
+        requested_model_grid = model_grid.lower()
+        if requested_model_grid not in utils.VALID_MODELS:
             raise NotImplementedError(
-                f'"{self.model_grid}" model grid not found. '
+                f'"{requested_model_grid}" model grid not found. '
                 + "Currently supported models are: "
                 + str(utils.VALID_MODELS)
             )
+        self.model_set = None
+        if requested_model_grid in utils.MPS_ATLAS_SELECTORS:
+            self.model_set = utils.normalize_mps_atlas_set(requested_model_grid)
+            self.model_grid = utils.canonical_mps_atlas_selector(self.model_set)
+        else:
+            self.model_grid = requested_model_grid
 
         # Define grid points
         sphinx_combinations = None
+        mps_atlas_combinations = None
         if self.model_grid == "sphinx":
             co_ratio = kwargs.get("co_ratio")
             (
@@ -2144,6 +2262,10 @@ class BinnedSpectralGrid(object):
                 self.co_ratio,
             ) = _sphinx_grid_slice(co_ratio)
             kwargs["co_ratio"] = self.co_ratio
+        elif self.model_set is not None:
+            self.grid_points, mps_atlas_combinations = _mps_atlas_grid_slice(
+                self.model_set
+            )
         else:
             self.grid_points = utils.GRID_POINTS[self.model_grid]
         self.grid_teffs = self.grid_points["grid_teffs"]
@@ -2195,16 +2317,21 @@ class BinnedSpectralGrid(object):
         self.upper = center + width / 2.0
 
         fluxes = {teff: {logg: {} for logg in self.loggs} for teff in self.teffs}
-        if self.model_grid == "sphinx":
+        sparse_combinations = (
+            sphinx_combinations
+            if self.model_grid == "sphinx"
+            else mps_atlas_combinations
+        )
+        if sparse_combinations is not None:
             within_bounds = (
-                (sphinx_combinations[:, 0] >= self.teff_bds[0])
-                & (sphinx_combinations[:, 0] <= self.teff_bds[1])
-                & (sphinx_combinations[:, 1] >= self.logg_bds[0])
-                & (sphinx_combinations[:, 1] <= self.logg_bds[1])
-                & (sphinx_combinations[:, 2] >= self.feh_bds[0])
-                & (sphinx_combinations[:, 2] <= self.feh_bds[1])
+                (sparse_combinations[:, 0] >= self.teff_bds[0])
+                & (sparse_combinations[:, 0] <= self.teff_bds[1])
+                & (sparse_combinations[:, 1] >= self.logg_bds[0])
+                & (sparse_combinations[:, 1] <= self.logg_bds[1])
+                & (sparse_combinations[:, 2] >= self.feh_bds[0])
+                & (sparse_combinations[:, 2] <= self.feh_bds[1])
             )
-            self.points = sphinx_combinations[within_bounds, :3]
+            self.points = sparse_combinations[within_bounds, :3]
             for teff, logg, feh in self.points:
                 bs = Spectrum.from_grid(
                     teff, logg, feh, model_grid=self.model_grid, **kwargs
@@ -2261,11 +2388,11 @@ class BinnedSpectralGrid(object):
                     message += f"\tInput {p}: {i}. Valid range: {r}\n"
             raise ValueError(message)
 
-        if self.model_grid == "sphinx":
+        if self.model_grid == "sphinx" or self.model_set is not None:
             if not self.points.size:
                 raise ValueError("BinnedSpectralGrid contains no spectra")
             if not interpolate:
-                nearest_index = _nearest_sphinx_index(
+                nearest_index = _nearest_available_index(
                     self.points, (teff, logg, feh)
                 )
                 nearest_teff, nearest_logg, nearest_feh = self.points[
@@ -2279,6 +2406,12 @@ class BinnedSpectralGrid(object):
                     (teff, logg, feh),
                 )
             except KeyError:
+                if self.model_set is not None:
+                    raise ValueError(
+                        f"Cannot interpolate this MPS-ATLAS {self.model_set} "
+                        "point because the selected set lacks a required corner "
+                        "model."
+                    ) from None
                 raise ValueError(
                     "Cannot interpolate this SPHINX point because the selected "
                     "C/O slice lacks a required corner model."

--- a/src/speclib/utils.py
+++ b/src/speclib/utils.py
@@ -2,6 +2,7 @@ import astropy.units as u
 import astropy.io.fits as fits
 import io
 import itertools
+import json
 import numpy as np
 import os
 import pooch
@@ -11,6 +12,7 @@ import tarfile
 import tempfile
 import urllib
 import warnings
+import zipfile
 from astropy.io import fits
 from contextlib import closing
 from pathlib import Path, PurePosixPath
@@ -20,9 +22,12 @@ __all__ = [
     "download_file",
     "download_phoenix_grid",
     "download_newera_grid",
+    "download_mps_atlas_grid",
     "download_sphinx_grid",
     "get_newera_record_id",
     "load_newera_model_list",
+    "load_mps_atlas_model_list",
+    "load_mps_atlas_spectrum",
     "find_bounds",
     "interpolate",
     "load_flux_array",
@@ -57,10 +62,108 @@ SPHINX_ARCHIVE_URL = (
     f"{SPHINX_ARCHIVE_FILENAME}/content"
 )
 
+MPS_ATLAS_DATASET_DOI = "doi:10.17617/3.NJ56TR"
+MPS_ATLAS_DATASET_API_URL = (
+    "https://edmond.mpg.de/api/datasets/:persistentId/"
+    f"?persistentId={MPS_ATLAS_DATASET_DOI}"
+)
+MPS_ATLAS_DATAFILE_URL = "https://edmond.mpg.de/api/access/datafile/{datafile_id}"
+MPS_ATLAS_ARCHIVES: dict[str, dict[str, str | int]] = {
+    "set1": {
+        "filename": "set1.zip",
+        "filesize": 9_503_312_271,
+        "md5": "91130159a9c486a27f1d67e176ae4c8b",
+    },
+    "set2": {
+        "filename": "set2.zip",
+        "filesize": 9_430_754_401,
+        "md5": "76b9cb4530acb96bc3da979d0e9ec119",
+    },
+}
+MPS_ATLAS_SELECTORS = {
+    "mps-atlas": "set1",
+    "mps-atlas-set1": "set1",
+    "mps-atlas-set2": "set2",
+}
+
+MPS_ATLAS_GRID_TEFFS = np.arange(3500.0, 9100.0, 100.0)
+MPS_ATLAS_GRID_LOGGS = np.array(
+    [3.0, 3.5, 4.0, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 5.0]
+)
+MPS_ATLAS_GRID_FEHS = np.array(
+    [
+        -5.0,
+        -4.5,
+        -4.0,
+        -3.5,
+        -3.0,
+        -2.5,
+        -2.4,
+        -2.3,
+        -2.2,
+        -2.1,
+        -2.0,
+        -1.9,
+        -1.8,
+        -1.7,
+        -1.6,
+        -1.5,
+        -1.4,
+        -1.3,
+        -1.2,
+        -1.1,
+        -1.0,
+        -0.95,
+        -0.9,
+        -0.85,
+        -0.8,
+        -0.75,
+        -0.7,
+        -0.65,
+        -0.6,
+        -0.55,
+        -0.5,
+        -0.45,
+        -0.4,
+        -0.35,
+        -0.3,
+        -0.25,
+        -0.2,
+        -0.15,
+        -0.1,
+        -0.05,
+        0.0,
+        0.05,
+        0.1,
+        0.15,
+        0.2,
+        0.25,
+        0.3,
+        0.35,
+        0.4,
+        0.45,
+        0.5,
+        0.6,
+        0.7,
+        0.8,
+        0.9,
+        1.0,
+        1.1,
+        1.2,
+        1.3,
+        1.4,
+        1.5,
+    ]
+)
+
 _LIBRARY_ROOT: Path | None = None
 _NEWERA_INDEX_CACHE: dict[tuple[Path, str], dict] = {}
 _NEWERA_TAR_MEMBER_CACHE: dict[Path, dict[str, str]] = {}
 _SPHINX_INDEX_CACHE: dict[Path, dict] = {}
+_MPS_ATLAS_INDEX_CACHE: dict[tuple[Path, str], dict] = {}
+_MPS_ATLAS_WAVELENGTH_PLAN_CACHE: dict[tuple[Path, str, tuple[int, int]], dict] = {}
+
+_MPS_ATLAS_DUPLICATE_FLUX_RTOL = 1e-12
 
 _NEWERA_MODEL_LINE_RE = re.compile(
     r"(?P<filename>"
@@ -78,6 +181,13 @@ _SPHINX_MODEL_FILENAME_RE = re.compile(
     r"_logg_(?P<logg>\d+(?:\.\d+)?)"
     r"_logZ_(?P<metallicity>[+-]\d+(?:\.\d+)?)"
     r"_CtoO_(?P<co_ratio>\d+(?:\.\d+)?)\.txt$"
+)
+
+_MPS_ATLAS_FLUX_MEMBER_RE = re.compile(
+    r"(?:^|/)MH(?P<metallicity>[+-]?\d+(?:\.\d+)?)"
+    r"/teff(?P<teff>\d+)"
+    r"/logg(?P<logg>[+-]?\d+(?:\.\d+)?)"
+    r"/mpsa_flux_spectra\.dat$"
 )
 
 
@@ -300,6 +410,502 @@ def _clear_directory(path: Path) -> None:
             shutil.rmtree(child)
         else:
             child.unlink()
+
+
+def normalize_mps_atlas_set(value: str) -> str:
+    """Return ``"set1"`` or ``"set2"`` for an MPS-ATLAS selector."""
+
+    normalized = str(value).lower()
+    if normalized in MPS_ATLAS_ARCHIVES:
+        return normalized
+    try:
+        return MPS_ATLAS_SELECTORS[normalized]
+    except KeyError as exc:
+        accepted = sorted([*MPS_ATLAS_ARCHIVES, *MPS_ATLAS_SELECTORS])
+        raise ValueError(
+            f"Unknown MPS-ATLAS set or selector '{value}'. "
+            f"Expected one of {accepted}."
+        ) from exc
+
+
+def canonical_mps_atlas_selector(value: str) -> str:
+    """Return the explicit public selector for an MPS-ATLAS set."""
+
+    return f"mps-atlas-{normalize_mps_atlas_set(value)}"
+
+
+def _mps_atlas_cache_dir(
+    model_set: str, library_root: str | Path | None = None
+) -> Path:
+    root = (
+        get_library_root()
+        if library_root is None
+        else Path(library_root).expanduser()
+    )
+    return root / "mps-atlas" / normalize_mps_atlas_set(model_set)
+
+
+def _resolve_mps_atlas_archive_url(model_set: str) -> str:
+    """Resolve a pinned MPS-ATLAS archive through the Edmond dataset API."""
+
+    model_set = normalize_mps_atlas_set(model_set)
+    expected = MPS_ATLAS_ARCHIVES[model_set]
+    try:
+        with urllib.request.urlopen(MPS_ATLAS_DATASET_API_URL) as response:
+            payload = json.load(response)
+    except Exception as exc:  # pragma: no cover - network dependent
+        raise RuntimeError(
+            "Unable to resolve the official MPS-ATLAS Edmond dataset: "
+            f"{exc}"
+        ) from exc
+
+    try:
+        files = payload["data"]["latestVersion"]["files"]
+    except (KeyError, TypeError) as exc:
+        raise RuntimeError(
+            "The Edmond MPS-ATLAS dataset response did not contain a released "
+            "file list."
+        ) from exc
+
+    for entry in files:
+        data_file = entry.get("dataFile", {})
+        if entry.get("label") != expected["filename"]:
+            continue
+
+        actual_size = data_file.get("filesize")
+        actual_md5 = data_file.get("md5") or data_file.get("checksum", {}).get(
+            "value"
+        )
+        if actual_md5 is not None:
+            actual_md5 = str(actual_md5).lower()
+        if actual_size != expected["filesize"] or actual_md5 != expected["md5"]:
+            raise RuntimeError(
+                f"The official {expected['filename']} metadata has changed from "
+                "the release pinned by speclib. Review the new MPS-ATLAS release "
+                "before updating its size or checksum."
+            )
+        try:
+            datafile_id = int(data_file["id"])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise RuntimeError(
+                f"The Edmond metadata for {expected['filename']} has no valid "
+                "data-file identifier."
+            ) from exc
+        return MPS_ATLAS_DATAFILE_URL.format(datafile_id=datafile_id)
+
+    raise RuntimeError(
+        f"The official Edmond record does not list {expected['filename']}."
+    )
+
+
+def _mps_atlas_verification_path(archive_path: Path) -> Path:
+    return archive_path.with_name(f".{archive_path.name}.verified-md5")
+
+
+def _clear_mps_atlas_runtime_cache(cache_dir: Path, model_set: str) -> None:
+    """Discard in-process index and wavelength plans for one selected set."""
+
+    resolved_cache = cache_dir.resolve()
+    _MPS_ATLAS_INDEX_CACHE.pop((resolved_cache, model_set), None)
+    stale_plan_keys = [
+        key
+        for key in _MPS_ATLAS_WAVELENGTH_PLAN_CACHE
+        if key[0].parent == resolved_cache and key[1] == model_set
+    ]
+    for key in stale_plan_keys:
+        _MPS_ATLAS_WAVELENGTH_PLAN_CACHE.pop(key, None)
+
+
+def _verify_cached_mps_atlas_archive(archive_path: Path, model_set: str) -> None:
+    """Validate a cached archive once, then retain a checksum marker."""
+
+    metadata = MPS_ATLAS_ARCHIVES[normalize_mps_atlas_set(model_set)]
+    expected_size = int(metadata["filesize"])
+    expected_md5 = str(metadata["md5"])
+    archive_stat = archive_path.stat()
+    actual_size = archive_stat.st_size
+    if actual_size != expected_size:
+        raise ValueError(
+            f"Cached MPS-ATLAS archive {archive_path} has size {actual_size} "
+            f"bytes; expected {expected_size}. Use overwrite=True to refresh it."
+        )
+
+    marker_path = _mps_atlas_verification_path(archive_path)
+    expected_marker = f"{expected_md5} {actual_size} {archive_stat.st_mtime_ns}"
+    if marker_path.exists() and marker_path.read_text().strip() == expected_marker:
+        return
+
+    actual_md5 = pooch.file_hash(archive_path, alg="md5")
+    if actual_md5 != expected_md5:
+        raise ValueError(
+            f"Cached MPS-ATLAS archive {archive_path} failed its published MD5 "
+            "checksum. Use overwrite=True to refresh it."
+        )
+    marker_path.write_text(f"{expected_marker}\n")
+
+
+def download_mps_atlas_grid(
+    model_set: str = "set1",
+    overwrite: bool = False,
+    library_root: str | Path | None = None,
+) -> Path:
+    """Download one official MPS-ATLAS model-set archive.
+
+    Parameters
+    ----------
+    model_set : {"set1", "set2"}, optional
+        Discrete MPS-ATLAS flavor. Public model selectors are also accepted;
+        ``"mps-atlas"`` resolves to Set 1.
+    overwrite : bool, optional
+        Clear only the selected set's cache and download it again.
+    library_root : str or Path, optional
+        Base cache directory. Defaults to :func:`get_library_root`.
+
+    Returns
+    -------
+    Path
+        Selected set cache directory under ``mps-atlas/<set>``.
+
+    Notes
+    -----
+    Edmond distributes each set as one approximately 9.5 GB ZIP archive.
+    This helper caches the ZIP without eagerly extracting its members.
+    """
+
+    model_set = normalize_mps_atlas_set(model_set)
+    metadata = MPS_ATLAS_ARCHIVES[model_set]
+    cache_dir = _mps_atlas_cache_dir(model_set, library_root)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    archive_path = cache_dir / str(metadata["filename"])
+
+    if overwrite:
+        _clear_directory(cache_dir)
+        _clear_mps_atlas_runtime_cache(cache_dir, model_set)
+    elif archive_path.exists():
+        try:
+            _verify_cached_mps_atlas_archive(archive_path, model_set)
+        except ValueError as exc:
+            archive_path.unlink(missing_ok=True)
+            _mps_atlas_verification_path(archive_path).unlink(missing_ok=True)
+            _clear_mps_atlas_runtime_cache(cache_dir, model_set)
+            raise ValueError(
+                f"{exc} The invalid cached archive was removed; retry to "
+                "download a fresh copy."
+            ) from exc
+        return cache_dir
+
+    required_bytes = int(metadata["filesize"])
+    available_bytes = shutil.disk_usage(cache_dir).free
+    if available_bytes < required_bytes:
+        raise OSError(
+            f"Downloading MPS-ATLAS {model_set} requires at least "
+            f"{required_bytes / 1024**3:.2f} GiB, but only "
+            f"{available_bytes / 1024**3:.2f} GiB is available in {cache_dir}."
+        )
+
+    url = _resolve_mps_atlas_archive_url(model_set)
+    try:
+        retrieved = Path(
+            pooch.retrieve(
+                url=url,
+                fname=str(metadata["filename"]),
+                path=cache_dir,
+                known_hash=f"md5:{metadata['md5']}",
+                processor=None,
+                progressbar=True,
+            )
+        )
+        if retrieved.stat().st_size != required_bytes:
+            raise ValueError(
+                f"Downloaded {metadata['filename']} has an unexpected size."
+            )
+    except Exception as exc:  # pragma: no cover - real download failure
+        archive_path.unlink(missing_ok=True)
+        _mps_atlas_verification_path(archive_path).unlink(missing_ok=True)
+        raise RuntimeError(
+            f"Unable to download MPS-ATLAS {model_set} from Edmond: {exc}"
+        ) from exc
+
+    archive_stat = archive_path.stat()
+    marker = f"{metadata['md5']} {archive_stat.st_size} {archive_stat.st_mtime_ns}"
+    _mps_atlas_verification_path(archive_path).write_text(f"{marker}\n")
+    _clear_mps_atlas_runtime_cache(cache_dir, model_set)
+    return cache_dir
+
+
+def _normalize_mps_atlas_key(
+    teff: float, logg: float, metallicity: float
+) -> tuple[float, float, float]:
+    values = [round(float(value), 8) for value in (teff, logg, metallicity)]
+    return tuple(0.0 if value == -0.0 else value for value in values)
+
+
+def load_mps_atlas_model_list(
+    model_set: str = "set1",
+    *,
+    library_root: str | Path | None = None,
+    cache_dir: str | Path | None = None,
+) -> dict:
+    """Index exact disk-integrated models in one MPS-ATLAS set archive."""
+
+    model_set = normalize_mps_atlas_set(model_set)
+    if cache_dir is None:
+        cache_dir = download_mps_atlas_grid(model_set, library_root=library_root)
+    else:
+        cache_dir = Path(cache_dir).expanduser()
+
+    cache_dir = Path(cache_dir).expanduser()
+    archive_path = cache_dir / str(MPS_ATLAS_ARCHIVES[model_set]["filename"])
+    if not archive_path.exists():
+        raise FileNotFoundError(
+            f"MPS-ATLAS {model_set} archive not found at {archive_path}. "
+            f"Run download_mps_atlas_grid('{model_set}') first."
+        )
+    cache_key = (cache_dir.resolve(), model_set)
+    signature = (archive_path.stat().st_size, archive_path.stat().st_mtime_ns)
+    cached = _MPS_ATLAS_INDEX_CACHE.get(cache_key)
+    if cached is not None and cached["archive_signature"] == signature:
+        return cached
+
+    entries: dict[tuple[float, float, float], str] = {}
+    try:
+        with zipfile.ZipFile(archive_path) as archive:
+            for info in archive.infolist():
+                if info.is_dir():
+                    continue
+                match = _MPS_ATLAS_FLUX_MEMBER_RE.search(info.filename)
+                if match is None:
+                    continue
+                key = _normalize_mps_atlas_key(
+                    match.group("teff"),
+                    match.group("logg"),
+                    match.group("metallicity"),
+                )
+                if key in entries and entries[key] != info.filename:
+                    raise ValueError(
+                        f"MPS-ATLAS {model_set} contains duplicate disk-integrated "
+                        f"members for Teff={key[0]}, logg={key[1]}, [M/H]={key[2]}."
+                    )
+                entries[key] = info.filename
+    except zipfile.BadZipFile as exc:
+        raise ValueError(
+            f"Cached MPS-ATLAS {model_set} archive is not a valid ZIP file: "
+            f"{archive_path}."
+        ) from exc
+
+    if not entries:
+        raise FileNotFoundError(
+            f"No mpsa_flux_spectra.dat members were found in {archive_path}."
+        )
+
+    combinations = np.array(sorted(entries), dtype=float)
+    result = {
+        "model_set": model_set,
+        "archive_path": archive_path,
+        "archive_signature": signature,
+        "entries": entries,
+        "combinations": combinations,
+        "grid_teffs": np.unique(combinations[:, 0]),
+        "grid_loggs": np.unique(combinations[:, 1]),
+        "grid_fehs": np.unique(combinations[:, 2]),
+    }
+    _MPS_ATLAS_INDEX_CACHE[cache_key] = result
+    return result
+
+
+def _validate_mps_atlas_spectrum_arrays(
+    wavelength: np.ndarray, flux: np.ndarray, member_name: str
+) -> None:
+    """Validate raw or normalized MPS-ATLAS wavelength/flux arrays."""
+
+    if wavelength.ndim != 1 or flux.ndim != 1:
+        raise ValueError(
+            f"MPS-ATLAS member {member_name} wavelength and flux must be "
+            "one-dimensional."
+        )
+    if wavelength.shape != flux.shape:
+        raise ValueError(
+            f"MPS-ATLAS member {member_name} has inconsistent wavelength and "
+            "flux lengths."
+        )
+    if wavelength.size == 0:
+        raise ValueError(f"MPS-ATLAS member {member_name} is empty.")
+    if not np.all(np.isfinite(wavelength)) or np.any(wavelength <= 0):
+        raise ValueError(
+            f"MPS-ATLAS member {member_name} contains nonfinite or nonpositive "
+            "wavelengths."
+        )
+    if not np.all(np.isfinite(flux)):
+        raise ValueError(
+            f"MPS-ATLAS member {member_name} contains nonfinite flux values."
+        )
+
+
+def _collapse_mps_atlas_duplicate_wavelengths(
+    wavelength: np.ndarray, flux: np.ndarray, member_name: str
+) -> tuple[np.ndarray, np.ndarray]:
+    """Collapse exact duplicate coordinates only when their fluxes agree."""
+
+    unique_wavelength, first_indices, counts = np.unique(
+        wavelength, return_index=True, return_counts=True
+    )
+    duplicate_groups = np.flatnonzero(counts > 1)
+    for group_index in duplicate_groups:
+        start = first_indices[group_index]
+        stop = start + counts[group_index]
+        duplicate_flux = flux[start:stop]
+        if not np.allclose(
+            duplicate_flux,
+            duplicate_flux[0],
+            rtol=_MPS_ATLAS_DUPLICATE_FLUX_RTOL,
+            atol=0.0,
+        ):
+            raise ValueError(
+                f"MPS-ATLAS member {member_name} contains duplicate wavelength "
+                f"{unique_wavelength[group_index]} nm with materially different "
+                "flux values; these samples cannot be collapsed safely."
+            )
+
+    keep = np.ones(wavelength.size, dtype=bool)
+    for start, count in zip(first_indices, counts):
+        if count > 1:
+            keep[start + 1 : start + count] = False
+    return wavelength[keep], flux[keep]
+
+
+def _normalize_mps_atlas_spectral_axis(
+    wavelength: np.ndarray,
+    flux: np.ndarray,
+    member_name: str,
+    *,
+    plan: dict | None = None,
+) -> tuple[np.ndarray, np.ndarray, dict]:
+    """Return paired MPS-ATLAS samples on a strictly increasing axis.
+
+    The released spectra share a nonmonotonic ODF wavelength sequence. The
+    flux samples remain paired to their coordinates while a stable sort puts
+    that sequence into ascending order. Exact duplicate coordinates are only
+    collapsed when their fluxes agree to a tight relative tolerance.
+    """
+
+    wavelength = np.asarray(wavelength, dtype=float)
+    flux = np.asarray(flux, dtype=float)
+    _validate_mps_atlas_spectrum_arrays(wavelength, flux, member_name)
+
+    if plan is not None and np.array_equal(wavelength, plan["raw_wavelength"]):
+        order = plan["order"]
+    else:
+        order = np.argsort(wavelength, kind="stable")
+
+    sorted_wavelength = wavelength[order]
+    sorted_flux = flux[order]
+    normalized_wavelength, normalized_flux = (
+        _collapse_mps_atlas_duplicate_wavelengths(
+            sorted_wavelength, sorted_flux, member_name
+        )
+    )
+    _validate_mps_atlas_spectrum_arrays(
+        normalized_wavelength, normalized_flux, member_name
+    )
+    if normalized_wavelength.size > 1 and not np.all(
+        np.diff(normalized_wavelength) > 0
+    ):
+        raise ValueError(
+            f"MPS-ATLAS member {member_name} could not be normalized to a "
+            "strictly increasing wavelength grid."
+        )
+
+    if plan is None or not np.array_equal(wavelength, plan["raw_wavelength"]):
+        plan = {
+            "raw_wavelength": wavelength.copy(),
+            "order": order,
+            "normalized_wavelength": normalized_wavelength.copy(),
+        }
+    else:
+        if not np.array_equal(
+            normalized_wavelength, plan["normalized_wavelength"]
+        ):
+            raise ValueError(
+                f"MPS-ATLAS member {member_name} does not match the cached "
+                "normalized wavelength grid."
+            )
+        normalized_wavelength = plan["normalized_wavelength"]
+
+    return normalized_wavelength, normalized_flux, plan
+
+
+def _mps_atlas_irradiance_to_surface_flux(
+    wavelength: u.Quantity, irradiance: u.Quantity
+) -> u.Quantity:
+    """Convert archive F_nu at 1 AU for R_sun to stellar-surface F_lambda."""
+
+    geometric_scale = ((1 * u.au) / (1 * u.R_sun)).decompose() ** 2
+    surface_flux_nu = irradiance * geometric_scale
+    return surface_flux_nu.to(
+        u.erg / (u.s * u.cm**2 * u.AA),
+        equivalencies=u.spectral_density(wavelength),
+    )
+
+
+def load_mps_atlas_spectrum(
+    teff: float,
+    logg: float,
+    metallicity: float,
+    model_set: str = "set1",
+    *,
+    library_root: str | Path | None = None,
+) -> tuple[u.Quantity, u.Quantity]:
+    """Load one exact disk-integrated MPS-ATLAS surface spectrum."""
+
+    model_set = normalize_mps_atlas_set(model_set)
+    model_list = load_mps_atlas_model_list(model_set, library_root=library_root)
+    key = _normalize_mps_atlas_key(teff, logg, metallicity)
+    try:
+        member_name = model_list["entries"][key]
+    except KeyError as exc:
+        raise ValueError(
+            f"MPS-ATLAS {model_set} has no disk-integrated model for "
+            f"Teff={teff}, logg={logg}, [M/H]={metallicity}."
+        ) from exc
+
+    try:
+        with zipfile.ZipFile(model_list["archive_path"]) as archive:
+            with archive.open(member_name) as source:
+                data = np.loadtxt(source, skiprows=1, ndmin=2)
+    except (KeyError, OSError, zipfile.BadZipFile, ValueError) as exc:
+        raise ValueError(
+            f"Unable to read MPS-ATLAS {model_set} member {member_name}: {exc}"
+        ) from exc
+
+    if data.ndim != 2 or data.shape[1] != 2:
+        raise ValueError(
+            f"MPS-ATLAS member {member_name} must contain wavelength and F_nu "
+            "columns."
+        )
+    wavelength_values = np.asarray(data[:, 0], dtype=float)
+    irradiance_values = np.asarray(data[:, 1], dtype=float)
+    plan_key = (
+        model_list["archive_path"].resolve(),
+        model_set,
+        model_list["archive_signature"],
+    )
+    cached_plan = _MPS_ATLAS_WAVELENGTH_PLAN_CACHE.get(plan_key)
+    wavelength_values, irradiance_values, normalization_plan = (
+        _normalize_mps_atlas_spectral_axis(
+            wavelength_values,
+            irradiance_values,
+            member_name,
+            plan=cached_plan,
+        )
+    )
+    if cached_plan is None:
+        _MPS_ATLAS_WAVELENGTH_PLAN_CACHE[plan_key] = normalization_plan
+
+    wavelength = wavelength_values * u.nm
+    irradiance = irradiance_values * (u.erg / (u.s * u.cm**2 * u.Hz))
+    return wavelength, _mps_atlas_irradiance_to_surface_flux(
+        wavelength, irradiance
+    )
 
 
 def _extract_sphinx_spectra(tar_path: Path, cache_dir: Path) -> None:
@@ -1207,6 +1813,8 @@ def air2vac(wl_air):
 VALID_MODELS = [
     "drift-phoenix",
     "mps-atlas",
+    "mps-atlas-set1",
+    "mps-atlas-set2",
     "newera",
     "newera_gaia",
     "newera_jwst",
@@ -1225,6 +1833,12 @@ newera_grid = {
     "grid_alphas": np.array([-0.2, 0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 1.2]),
 }
 
+mps_atlas_grid = {
+    "grid_teffs": MPS_ATLAS_GRID_TEFFS,
+    "grid_loggs": MPS_ATLAS_GRID_LOGGS,
+    "grid_fehs": MPS_ATLAS_GRID_FEHS,
+}
+
 GRID_POINTS = {
     "drift-phoenix": {
         # Grid of effective temperatures
@@ -1234,78 +1848,10 @@ GRID_POINTS = {
         # Grid of metallicities
         "grid_fehs": np.array([-0.6, -0.3, -0.0, 0.3]),
     },
-    "mps-atlas": {
-        # Grid of effective temperatures
-        "grid_teffs": np.arange(3500, 9100, 100),
-        # Grid of surface gravities
-        "grid_loggs": np.array([3.0, 3.5, 4.0, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 5.0]),
-        # Grid of metallicities
-        "grid_fehs": np.array(
-            [
-                -5.0,
-                -4.5,
-                -4.0,
-                -3.5,
-                -3.0,
-                -2.5,
-                -2.4,
-                -2.3,
-                -2.2,
-                -2.1,
-                -2.0,
-                -1.9,
-                -1.8,
-                -1.7,
-                -1.6,
-                -1.5,
-                -1.4,
-                -1.3,
-                -1.2,
-                -1.1,
-                -1.0,
-                -0.95,
-                -0.9,
-                -0.85,
-                -0.8,
-                -0.75,
-                -0.7,
-                -0.65,
-                -0.6,
-                -0.55,
-                -0.5,
-                -0.45,
-                -0.4,
-                -0.35,
-                -0.3,
-                -0.25,
-                -0.2,
-                -0.15,
-                -0.1,
-                -0.05,
-                0.0,
-                0.05,
-                0.1,
-                0.15,
-                0.2,
-                0.25,
-                0.3,
-                0.35,
-                0.4,
-                0.45,
-                0.5,
-                0.6,
-                0.7,
-                0.8,
-                0.9,
-                1.0,
-                1.1,
-                1.2,
-                1.3,
-                1.4,
-                1.5,
-            ]
-        ),
-    },
+    # MPS-ATLAS availability is refined from the selected ZIP at runtime.
+    "mps-atlas": mps_atlas_grid,
+    "mps-atlas-set1": mps_atlas_grid,
+    "mps-atlas-set2": mps_atlas_grid,
     "newera": newera_grid,
     "newera_gaia": newera_grid,
     "newera_jwst": newera_grid,

--- a/tests/test_mps_atlas.py
+++ b/tests/test_mps_atlas.py
@@ -1,0 +1,535 @@
+import hashlib
+import io
+import json
+import shutil
+import zipfile
+
+import astropy.units as u
+import numpy as np
+import pytest
+
+from speclib import download_mps_atlas_grid as public_download_mps_atlas_grid
+from speclib import utils
+from speclib.core import BinnedSpectralGrid, Spectrum, SpectralGrid
+
+
+# Exact local ordering around the sole reversal in the v3 production archive.
+WAVELENGTH_NM = np.array(
+    [
+        85.79684217280924,
+        87.06691955221062,
+        91.07195158078505,
+        87.58558147727098,
+        89.07737142457651,
+        90.21800420659785,
+        91.28453967606204,
+    ]
+)
+
+
+def _spectrum_text(scale, wavelengths=WAVELENGTH_NM):
+    rows = ["wavelength_nm fnu_at_1au"]
+    rows.extend(
+        f"{wavelength} {scale * value}"
+        for wavelength, value in zip(
+            wavelengths, np.arange(1.0, len(wavelengths) + 1.0)
+        )
+    )
+    return "\n".join(rows) + "\n"
+
+
+def _member_name(model_set, teff, logg, metallicity):
+    return (
+        f"{model_set}/MH{metallicity}/teff{teff:.0f}/logg{logg:.1f}/"
+        "mpsa_flux_spectra.dat"
+    )
+
+
+def _write_archive(root, model_set, models):
+    cache_dir = root / "mps-atlas" / model_set
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    archive_path = cache_dir / f"{model_set}.zip"
+    with zipfile.ZipFile(
+        archive_path, "w", compression=zipfile.ZIP_DEFLATED
+    ) as archive:
+        for (teff, logg, metallicity), scale in models.items():
+            archive.writestr(
+                _member_name(model_set, teff, logg, metallicity),
+                _spectrum_text(scale),
+            )
+        archive.writestr(f"{model_set}/README.txt", "ignored")
+    return cache_dir
+
+
+def _cube_models(multiplier=1.0):
+    models = {}
+    for teff in (3500.0, 3600.0):
+        for logg in (3.0, 3.5):
+            for metallicity in (0.0, 0.1):
+                scale = (
+                    1.0
+                    + (teff - 3500.0) / 100.0
+                    + 2.0 * (logg - 3.0) / 0.5
+                    + 4.0 * metallicity / 0.1
+                )
+                models[(teff, logg, metallicity)] = multiplier * scale
+    return models
+
+
+@pytest.fixture
+def mps_atlas_cache(monkeypatch, tmp_path):
+    _write_archive(tmp_path, "set1", _cube_models())
+    _write_archive(tmp_path, "set2", _cube_models(multiplier=10.0))
+
+    def use_cached_archive(model_set="set1", overwrite=False, library_root=None):
+        del overwrite
+        root = tmp_path if library_root is None else library_root
+        return root / "mps-atlas" / utils.normalize_mps_atlas_set(model_set)
+
+    monkeypatch.setattr(utils, "download_mps_atlas_grid", use_cached_archive)
+    utils._MPS_ATLAS_INDEX_CACHE.clear()
+    utils._MPS_ATLAS_WAVELENGTH_PLAN_CACHE.clear()
+    utils.set_library_root(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        utils.set_library_root(None)
+        utils._MPS_ATLAS_INDEX_CACHE.clear()
+        utils._MPS_ATLAS_WAVELENGTH_PLAN_CACHE.clear()
+
+
+def test_download_mps_atlas_grid_public_alias():
+    assert public_download_mps_atlas_grid is utils.download_mps_atlas_grid
+
+
+def test_resolve_mps_atlas_archive_uses_pinned_edmond_metadata(monkeypatch):
+    metadata = utils.MPS_ATLAS_ARCHIVES["set2"]
+    payload = {
+        "data": {
+            "latestVersion": {
+                "files": [
+                    {
+                        "label": metadata["filename"],
+                        "dataFile": {
+                            "id": 12345,
+                            "filesize": metadata["filesize"],
+                            "md5": metadata["md5"],
+                        },
+                    }
+                ]
+            }
+        }
+    }
+
+    class Response(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            self.close()
+
+    monkeypatch.setattr(
+        utils.urllib.request,
+        "urlopen",
+        lambda url: Response(json.dumps(payload).encode()),
+    )
+
+    assert utils._resolve_mps_atlas_archive_url("set2") == (
+        "https://edmond.mpg.de/api/access/datafile/12345"
+    )
+
+
+def test_resolve_mps_atlas_archive_rejects_changed_release(monkeypatch):
+    payload = {
+        "data": {
+            "latestVersion": {
+                "files": [
+                    {
+                        "label": "set1.zip",
+                        "dataFile": {
+                            "id": 1,
+                            "filesize": 1,
+                            "md5": "changed",
+                        },
+                    }
+                ]
+            }
+        }
+    }
+
+    class Response(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            self.close()
+
+    monkeypatch.setattr(
+        utils.urllib.request,
+        "urlopen",
+        lambda url: Response(json.dumps(payload).encode()),
+    )
+    with pytest.raises(RuntimeError, match="metadata has changed"):
+        utils._resolve_mps_atlas_archive_url("set1")
+
+
+def test_download_mps_atlas_grid_caches_sets_separately(monkeypatch, tmp_path):
+    source_root = tmp_path / "source"
+    source_cache = _write_archive(
+        source_root, "set1", {(3500.0, 3.0, 0.0): 1.0}
+    )
+    source_archive = source_cache / "set1.zip"
+    archive_bytes = source_archive.read_bytes()
+    metadata = {
+        "set1": {
+            "filename": "set1.zip",
+            "filesize": len(archive_bytes),
+            "md5": hashlib.md5(archive_bytes).hexdigest(),
+        },
+        "set2": utils.MPS_ATLAS_ARCHIVES["set2"],
+    }
+    monkeypatch.setattr(utils, "MPS_ATLAS_ARCHIVES", metadata)
+    monkeypatch.setattr(
+        utils, "_resolve_mps_atlas_archive_url", lambda model_set: "mock://set1"
+    )
+    retrievals = []
+
+    def fake_retrieve(**kwargs):
+        retrievals.append(kwargs)
+        target = kwargs["path"] / kwargs["fname"]
+        shutil.copyfile(source_archive, target)
+        return str(target)
+
+    monkeypatch.setattr(utils.pooch, "retrieve", fake_retrieve)
+    cache_root = tmp_path / "cache"
+
+    result = utils.download_mps_atlas_grid("mps-atlas", library_root=cache_root)
+    assert result == cache_root / "mps-atlas" / "set1"
+    assert retrievals[0]["known_hash"] == f"md5:{metadata['set1']['md5']}"
+    assert (result / ".set1.zip.verified-md5").exists()
+
+    utils.download_mps_atlas_grid("set1", library_root=cache_root)
+    assert len(retrievals) == 1
+
+    stale = result / "stale.txt"
+    stale.write_text("stale")
+    set2_cache = cache_root / "mps-atlas" / "set2"
+    set2_cache.mkdir()
+    set2_marker = set2_cache / "keep.txt"
+    set2_marker.write_text("set 2")
+    utils.download_mps_atlas_grid("set1", overwrite=True, library_root=cache_root)
+    assert len(retrievals) == 2
+    assert not stale.exists()
+    assert set2_marker.read_text() == "set 2"
+
+
+def test_download_mps_atlas_grid_removes_partial_and_corrupt_files(
+    monkeypatch, tmp_path
+):
+    metadata = {
+        "set1": {"filename": "set1.zip", "filesize": 10, "md5": "0" * 32},
+        "set2": utils.MPS_ATLAS_ARCHIVES["set2"],
+    }
+    monkeypatch.setattr(utils, "MPS_ATLAS_ARCHIVES", metadata)
+    monkeypatch.setattr(
+        utils, "_resolve_mps_atlas_archive_url", lambda model_set: "mock://set1"
+    )
+
+    def interrupted_retrieve(**kwargs):
+        target = kwargs["path"] / kwargs["fname"]
+        target.write_bytes(b"partial")
+        raise OSError("connection interrupted")
+
+    monkeypatch.setattr(utils.pooch, "retrieve", interrupted_retrieve)
+    cache_root = tmp_path / "cache"
+    archive_path = cache_root / "mps-atlas" / "set1" / "set1.zip"
+    with pytest.raises(RuntimeError, match="connection interrupted"):
+        utils.download_mps_atlas_grid("set1", library_root=cache_root)
+    assert not archive_path.exists()
+
+    archive_path.write_bytes(b"bad-length")
+    with pytest.raises(ValueError, match="invalid cached archive was removed"):
+        utils.download_mps_atlas_grid("set1", library_root=cache_root)
+    assert not archive_path.exists()
+
+
+def test_mps_atlas_published_axes_are_declared_for_both_sets():
+    expected_teffs = np.arange(3500.0, 9100.0, 100.0)
+    expected_loggs = np.array([3.0, 3.5, 4.0, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 5.0])
+    assert len(utils.MPS_ATLAS_GRID_FEHS) == 61
+    np.testing.assert_array_equal(utils.MPS_ATLAS_GRID_TEFFS, expected_teffs)
+    np.testing.assert_array_equal(utils.MPS_ATLAS_GRID_LOGGS, expected_loggs)
+    assert utils.MPS_ATLAS_GRID_FEHS[0] == -5.0
+    assert utils.MPS_ATLAS_GRID_FEHS[-1] == 1.5
+    for selector in ("mps-atlas-set1", "mps-atlas-set2"):
+        np.testing.assert_array_equal(
+            utils.GRID_POINTS[selector]["grid_teffs"], expected_teffs
+        )
+        np.testing.assert_array_equal(
+            utils.GRID_POINTS[selector]["grid_loggs"], expected_loggs
+        )
+        np.testing.assert_array_equal(
+            utils.GRID_POINTS[selector]["grid_fehs"], utils.MPS_ATLAS_GRID_FEHS
+        )
+
+
+def test_mps_atlas_index_and_physical_unit_conversion(mps_atlas_cache):
+    model_list = utils.load_mps_atlas_model_list("set1")
+    set2_model_list = utils.load_mps_atlas_model_list("set2")
+    assert model_list["model_set"] == "set1"
+    assert model_list["combinations"].shape == (8, 3)
+    np.testing.assert_array_equal(model_list["grid_teffs"], [3500.0, 3600.0])
+    np.testing.assert_array_equal(model_list["grid_loggs"], [3.0, 3.5])
+    np.testing.assert_array_equal(model_list["grid_fehs"], [0.0, 0.1])
+    assert model_list["archive_path"] != set2_model_list["archive_path"]
+    assert model_list["entries"] is not set2_model_list["entries"]
+    assert not list(mps_atlas_cache.rglob("mpsa_flux_spectra.dat"))
+
+    wavelength, flux = utils.load_mps_atlas_spectrum(3500.0, 3.0, 0.0, "set1")
+    order = np.argsort(WAVELENGTH_NM, kind="stable")
+    expected_wavelength = WAVELENGTH_NM[order] * u.nm
+    expected_fnu = np.arange(1.0, len(WAVELENGTH_NM) + 1.0)[order] * u.erg / (
+        u.s * u.cm**2 * u.Hz
+    )
+    expected_flux = (
+        expected_fnu * ((1 * u.au) / (1 * u.R_sun)).decompose() ** 2
+    ).to(
+        u.erg / (u.s * u.cm**2 * u.AA),
+        equivalencies=u.spectral_density(expected_wavelength),
+    )
+
+    assert wavelength.unit == u.nm
+    assert flux.unit == u.erg / (u.s * u.cm**2 * u.AA)
+    np.testing.assert_allclose(wavelength.value, WAVELENGTH_NM[order])
+    np.testing.assert_allclose(flux.value, expected_flux.value)
+
+
+def test_mps_atlas_wavelength_normalization_preserves_flux_pairing():
+    raw_flux = np.arange(1.0, len(WAVELENGTH_NM) + 1.0)
+    wavelength, flux, plan = utils._normalize_mps_atlas_spectral_axis(
+        WAVELENGTH_NM, raw_flux, "production-pathology.dat"
+    )
+    order = np.argsort(WAVELENGTH_NM, kind="stable")
+
+    np.testing.assert_array_equal(wavelength, WAVELENGTH_NM[order])
+    np.testing.assert_array_equal(flux, raw_flux[order])
+    assert np.all(np.diff(wavelength) > 0)
+
+    _, scaled_flux, reused_plan = utils._normalize_mps_atlas_spectral_axis(
+        WAVELENGTH_NM,
+        2.0 * raw_flux,
+        "same-grid-second-model.dat",
+        plan=plan,
+    )
+    np.testing.assert_array_equal(scaled_flux, 2.0 * raw_flux[order])
+    assert reused_plan is plan
+
+
+def test_mps_atlas_identical_duplicate_wavelengths_are_collapsed():
+    wavelength = np.array([10.0, 20.0, 20.0, 30.0])
+    flux = np.array([1.0, 2.0, 2.0 * (1.0 + 5e-13), 3.0])
+
+    normalized_wavelength, normalized_flux, _ = (
+        utils._normalize_mps_atlas_spectral_axis(
+            wavelength, flux, "equivalent-duplicates.dat"
+        )
+    )
+
+    np.testing.assert_array_equal(normalized_wavelength, [10.0, 20.0, 30.0])
+    np.testing.assert_array_equal(normalized_flux, [1.0, 2.0, 3.0])
+
+
+def test_mps_atlas_conflicting_duplicate_wavelengths_raise():
+    wavelength = np.array([10.0, 20.0, 20.0, 30.0])
+    flux = np.array([1.0, 2.0, 2.01, 3.0])
+
+    with pytest.raises(ValueError, match="materially different flux values"):
+        utils._normalize_mps_atlas_spectral_axis(
+            wavelength, flux, "conflicting-duplicates.dat"
+        )
+
+
+def test_mps_atlas_near_duplicate_wavelengths_are_not_merged():
+    neighboring_value = np.nextafter(20.0, np.inf)
+    wavelength = np.array([10.0, 20.0, neighboring_value, 30.0])
+    flux = np.array([1.0, 2.0, 2.5, 3.0])
+
+    normalized_wavelength, normalized_flux, _ = (
+        utils._normalize_mps_atlas_spectral_axis(
+            wavelength, flux, "near-duplicates.dat"
+        )
+    )
+
+    np.testing.assert_array_equal(normalized_wavelength, wavelength)
+    np.testing.assert_array_equal(normalized_flux, flux)
+    assert len(normalized_wavelength) == 4
+
+
+def test_mps_atlas_alias_and_explicit_sets_remain_distinct(mps_atlas_cache):
+    alias = Spectrum.from_grid(
+        3500.0, 3.0, 0.0, model_grid="mps-atlas", interpolate=False
+    )
+    set1 = Spectrum.from_grid(
+        3500.0, 3.0, 0.0, model_grid="mps-atlas-set1", interpolate=False
+    )
+    set2 = Spectrum.from_grid(
+        3500.0, 3.0, 0.0, model_grid="mps-atlas-set2", interpolate=False
+    )
+
+    assert alias.model_grid == "mps-atlas-set1"
+    assert alias.model_set == "set1"
+    assert set2.model_grid == "mps-atlas-set2"
+    assert set2.model_set == "set2"
+    assert alias.flux.ndim == 1
+    assert np.all(np.diff(alias.wavelength) > 0 * u.AA)
+    np.testing.assert_allclose(alias.flux.value, set1.flux.value)
+    np.testing.assert_allclose(set2.flux.value, 10.0 * set1.flux.value)
+
+
+def test_mps_atlas_spectrum_interpolation_and_nearest(mps_atlas_cache):
+    interpolated = Spectrum.from_grid(
+        3550.0, 3.25, 0.05, model_grid="mps-atlas-set1"
+    )
+    lower = Spectrum.from_grid(
+        3500.0, 3.0, 0.0, model_grid="mps-atlas-set1"
+    )
+    nearest = Spectrum.from_grid(
+        3501.0,
+        3.01,
+        0.001,
+        model_grid="mps-atlas-set1",
+        interpolate=False,
+    )
+
+    np.testing.assert_allclose(interpolated.flux.value, 4.5 * lower.flux.value)
+    np.testing.assert_allclose(nearest.flux.value, lower.flux.value)
+
+
+def test_mps_atlas_interpolation_never_uses_other_set(monkeypatch, tmp_path):
+    _write_archive(
+        tmp_path,
+        "set1",
+        {
+            (3500.0, 3.0, 0.0): 1.0,
+            (3500.0, 3.5, 0.0): 2.0,
+            (3600.0, 3.0, 0.0): 3.0,
+            (3600.0, 3.5, 0.0): 4.0,
+        },
+    )
+    _write_archive(
+        tmp_path,
+        "set2",
+        {
+            (3500.0, 3.0, 0.0): 10.0,
+            (3600.0, 3.5, 0.0): 40.0,
+        },
+    )
+
+    def use_cached_archive(model_set="set1", overwrite=False, library_root=None):
+        del overwrite, library_root
+        return tmp_path / "mps-atlas" / utils.normalize_mps_atlas_set(model_set)
+
+    monkeypatch.setattr(utils, "download_mps_atlas_grid", use_cached_archive)
+    utils._MPS_ATLAS_INDEX_CACHE.clear()
+    utils._MPS_ATLAS_WAVELENGTH_PLAN_CACHE.clear()
+    utils.set_library_root(tmp_path)
+    try:
+        set1 = Spectrum.from_grid(
+            3550.0, 3.25, 0.0, model_grid="mps-atlas-set1"
+        )
+        with pytest.raises(ValueError, match="selected set lacks a required corner"):
+            Spectrum.from_grid(
+                3550.0, 3.25, 0.0, model_grid="mps-atlas-set2"
+            )
+    finally:
+        utils.set_library_root(None)
+        utils._MPS_ATLAS_INDEX_CACHE.clear()
+        utils._MPS_ATLAS_WAVELENGTH_PLAN_CACHE.clear()
+
+    assert set1.model_set == "set1"
+
+
+def test_mps_atlas_interpolation_rejects_incompatible_wavelengths(
+    monkeypatch, tmp_path
+):
+    cache_dir = _write_archive(tmp_path, "set1", _cube_models())
+    archive_path = cache_dir / "set1.zip"
+    with zipfile.ZipFile(
+        archive_path, "w", compression=zipfile.ZIP_DEFLATED
+    ) as archive:
+        for parameters, scale in _cube_models().items():
+            text = (
+                _spectrum_text(scale, np.array([101.0, 201.0, 401.0]))
+                if parameters == (3600.0, 3.5, 0.1)
+                else _spectrum_text(scale)
+            )
+            archive.writestr(_member_name("set1", *parameters), text)
+
+    def use_cached_archive(model_set="set1", overwrite=False, library_root=None):
+        del model_set, overwrite, library_root
+        return cache_dir
+
+    monkeypatch.setattr(utils, "download_mps_atlas_grid", use_cached_archive)
+    utils._MPS_ATLAS_INDEX_CACHE.clear()
+    utils._MPS_ATLAS_WAVELENGTH_PLAN_CACHE.clear()
+    utils.set_library_root(tmp_path)
+    try:
+        with pytest.raises(ValueError, match="do not share a wavelength grid"):
+            Spectrum.from_grid(
+                3550.0, 3.25, 0.05, model_grid="mps-atlas-set1"
+            )
+    finally:
+        utils.set_library_root(None)
+        utils._MPS_ATLAS_INDEX_CACHE.clear()
+        utils._MPS_ATLAS_WAVELENGTH_PLAN_CACHE.clear()
+
+
+def test_mps_atlas_spectral_and_binned_grids(mps_atlas_cache):
+    grid = SpectralGrid(
+        (3500.0, 3600.0),
+        (3.0, 3.5),
+        (0.0, 0.1),
+        model_grid="mps-atlas-set2",
+    )
+    expected = Spectrum.from_grid(
+        3550.0, 3.25, 0.05, model_grid="mps-atlas-set2"
+    )
+    assert grid.model_grid == "mps-atlas-set2"
+    assert grid.model_set == "set2"
+    np.testing.assert_allclose(
+        grid.get_flux(3550.0, 3.25, 0.05).value,
+        expected.flux.value,
+    )
+
+    binned = BinnedSpectralGrid(
+        (3500.0, 3600.0),
+        (3.0, 3.5),
+        (0.0, 0.1),
+        center=np.array([870.0, 905.0]) * u.AA,
+        width=np.array([35.0, 40.0]) * u.AA,
+        model_grid="mps-atlas-set1",
+    )
+    assert binned.model_set == "set1"
+    assert binned.get_spectrum(3550.0, 3.25, 0.05).shape == (2,)
+
+
+def test_mps_atlas_cache_root_override_and_invalid_requests(
+    mps_atlas_cache, monkeypatch
+):
+    calls = []
+    real_download = utils.download_mps_atlas_grid
+
+    def record_download(model_set="set1", overwrite=False, library_root=None):
+        calls.append((model_set, library_root))
+        return real_download(model_set, overwrite, library_root)
+
+    monkeypatch.setattr(utils, "download_mps_atlas_grid", record_download)
+    utils.load_mps_atlas_model_list("mps-atlas-set2", library_root=mps_atlas_cache)
+    assert calls[-1] == ("set2", mps_atlas_cache)
+
+    with pytest.raises(ValueError, match="has no disk-integrated model"):
+        utils.load_mps_atlas_spectrum(3700.0, 3.0, 0.0, "set1")
+    with pytest.raises(ValueError, match="outside the available range"):
+        Spectrum.from_grid(3400.0, 3.0, 0.0, model_grid="mps-atlas-set1")
+    with pytest.raises(ValueError, match="Unknown MPS-ATLAS"):
+        utils.normalize_mps_atlas_set("set3")


### PR DESCRIPTION
## Summary

- Adds first-class disk-integrated MPS-ATLAS support through `mps-atlas`, `mps-atlas-set1`, and `mps-atlas-set2`; the generic selector aliases Set 1.
- Replaces the legacy undifferentiated, manually populated MPS-ATLAS cache path with automatic acquisition and set-aware loading.
- Keeps Set 1 and Set 2 separate in metadata, cache storage, archive indexes, model loading, nearest selection, and interpolation.

## Implementation

- Resolves the official Edmond v3 archives, validates pinned size and MD5 metadata, checks disk space, downloads and caches each set independently, and cleans up corrupt or interrupted downloads.
- Indexes production ZIP members and reads disk-integrated spectra directly from the archives without eager extraction.
- Supports exact, nearest-actual, and trilinear retrieval through `Spectrum`, `SpectralGrid`, and `BinnedSpectralGrid`.
- Restricts interpolation to supported stellar parameters within the selected set. Set 1 and Set 2 are never combined, and missing corners or incompatible wavelength grids raise explicit errors instead of silently falling back.

## Scientific/data handling

- Converts upstream `F_nu` at 1 AU to surface `F_lambda` using `(AU/Rsun)^2` and Astropy spectral-density equivalencies.
- Canonicalizes MPS-ATLAS wavelength axes with a stable ascending sort while preserving wavelength/flux pairing, collapses only exactly repeated coordinates with strictly consistent fluxes, and verifies that the final axis is strictly increasing.
- This normalization is needed because sampled Set 1 production files contain the same local wavelength reversal. The loader fixes the ordering before exposing the spectrum to `specutils`.

## Documentation

- Adds MPS-ATLAS as a first-class model library, including its Set 1/Set 2 distinctions, cache and interpolation behavior, installation/storage guidance, citations, and comparisons with the other supported libraries.

## Validation

- MPS-ATLAS tests: 17 passed.
- Full test suite: 88 passed.
- Tox:
  - Python 3.11: 88 passed.
  - Python 3.12: 88 passed.
  - Python 3.13: 88 passed.
- Warning-as-error documentation build passed.
- `git diff --check` passed.
- Compilation checks passed.
- Live Set 1 production-archive smoke test passed, covering real Edmond archive access, production ZIP indexing, exact retrieval, `mps-atlas` alias behavior, cached reload, interpolation, nearest-model retrieval, a strictly increasing 1,221-point wavelength axis, and wavelength/flux units.
- Set 2 is covered by offline tests but was not live-downloaded because its production archive is approximately 9.5 GB.

## Scope

This PR exposes disk-integrated spectra only. Center-to-limb `I_lambda(mu)` support remains out of scope.

Closes #75
